### PR TITLE
Utilize an Immutable Store Pattern in Services

### DIFF
--- a/src/app/modules/core/services/beacon-node.service.ts
+++ b/src/app/modules/core/services/beacon-node.service.ts
@@ -2,10 +2,11 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { interval } from 'rxjs';
-import { tap, startWith, mergeMap, switchMap } from 'rxjs/operators';
+import { tap, startWith, mergeMap } from 'rxjs/operators';
 
+import { Store } from 'src/app/modules/core/utils/simple-store';
+import { select$ } from 'src/app/modules/core/utils/select$';
 import { EnvironmenterService } from './environmenter.service';
-import { WalletService } from './wallet.service';
 
 import {
   NodeConnectionResponse,
@@ -21,20 +22,32 @@ export class BeaconNodeService {
   constructor(
     private http: HttpClient,
     private environmenter: EnvironmenterService,
-    private walletService: WalletService,
   ) { }
 
   private apiUrl = this.environmenter.env.validatorEndpoint;
-  private beaconNodeEndpoint: string;
+
+  // Create a reliable, immutable store for storing the 
+  // connection response with replayability.
+  beaconNodeState$ = new Store({} as NodeConnectionResponse);
+  beaconNodeEndpoint$ = select$(
+    this.beaconNodeState$,
+    res => res.beaconNodeEndpoint + BEACON_API_SUFFIX,
+  );
+  beaconNodeConnected$ = select$(
+    this.beaconNodeState$,
+    res => res.connected,
+  );
+  beaconNodeSyncing$ = select$(
+    this.beaconNodeState$,
+    res => res.syncing,
+  );
 
   // Observables.
-  status$ = this.http.get<NodeConnectionResponse>(`${this.apiUrl}/health/node_connection`).pipe(
-    tap((res: NodeConnectionResponse) => {
-      this.beaconNodeEndpoint = res.beaconNodeEndpoint + BEACON_API_SUFFIX;
-    }),
-  );
-  statusPoll$ = interval(POLLING_INTERVAL).pipe(
+  nodeStatusPoll$ = interval(POLLING_INTERVAL).pipe(
     startWith(0),
-    mergeMap(_ => this.status$),
+    mergeMap(_ => this.http.get<NodeConnectionResponse>(`${this.apiUrl}/health/node_connection`)),
+    tap((res: NodeConnectionResponse) => {
+      this.beaconNodeState$.next(res);
+    })
   );
 }

--- a/src/app/modules/core/services/beacon-node.service.ts
+++ b/src/app/modules/core/services/beacon-node.service.ts
@@ -31,15 +31,15 @@ export class BeaconNodeService {
   beaconNodeState$ = new Store({} as NodeConnectionResponse);
   beaconNodeEndpoint$ = select$(
     this.beaconNodeState$,
-    res => res.beaconNodeEndpoint + BEACON_API_SUFFIX,
+    (res: NodeConnectionResponse) => res.beaconNodeEndpoint + BEACON_API_SUFFIX,
   );
   beaconNodeConnected$ = select$(
     this.beaconNodeState$,
-    res => res.connected,
+    (res: NodeConnectionResponse) => res.connected,
   );
   beaconNodeSyncing$ = select$(
     this.beaconNodeState$,
-    res => res.syncing,
+    (res: NodeConnectionResponse) => res.syncing,
   );
 
   // Observables.
@@ -48,6 +48,6 @@ export class BeaconNodeService {
     mergeMap(_ => this.http.get<NodeConnectionResponse>(`${this.apiUrl}/health/node_connection`)),
     tap((res: NodeConnectionResponse) => {
       this.beaconNodeState$.next(res);
-    })
+    }),
   );
 }

--- a/src/app/modules/core/utils/deep-freeze.spec.ts
+++ b/src/app/modules/core/utils/deep-freeze.spec.ts
@@ -1,0 +1,43 @@
+import deepFreeze from './deep-freeze';
+
+describe('Deep freeze', () => {
+  it(`should not allow modification of a frozen object's properties`, () => {
+    const unfrozen = {
+      title: 'Foo',
+      subtitle: 'Bar',
+    };
+    unfrozen.title = 'Hello world';
+    expect(unfrozen.title).toEqual('Hello world');
+    const frozen = deepFreeze(unfrozen);
+    const modify = () => {
+      try {
+        frozen.title = 'Hello world'
+      } catch (err) {
+        throw(err);
+      }
+    };
+    expect(modify).toThrowError();
+  });
+  it(`should disallow deep modification of inner objects`, () => {
+    const unfrozen = {
+      title: 'Foo',
+      subtitle: 'Bar',
+      details: {
+        reviews: 5,
+      },
+    };
+    unfrozen.title = 'Hello world';
+    expect(unfrozen.title).toEqual('Hello world');
+    unfrozen.details.reviews = 10;
+    expect(unfrozen.details.reviews).toEqual(10);
+    const frozen = deepFreeze(unfrozen);
+    const modifyDeep = () => {
+      try {
+        frozen.details.reviews = 1;
+      } catch (err) {
+        throw(err);
+      }
+    };
+    expect(modifyDeep).toThrowError();
+  });
+});

--- a/src/app/modules/core/utils/deep-freeze.ts
+++ b/src/app/modules/core/utils/deep-freeze.ts
@@ -1,0 +1,12 @@
+export default function deepFreeze<T>(inObj: T): T {
+  Object.freeze(inObj);
+  Object.getOwnPropertyNames(inObj).forEach(function (prop) {
+    if (inObj.hasOwnProperty(prop)
+      && inObj[prop] != null
+      && typeof inObj[prop] === 'object'
+      && !Object.isFrozen(inObj[prop])) {
+        deepFreeze(inObj[prop]);
+      }
+  });
+  return inObj;
+}

--- a/src/app/modules/core/utils/select$.spec.ts
+++ b/src/app/modules/core/utils/select$.spec.ts
@@ -1,0 +1,35 @@
+import { take } from 'rxjs/operators';
+
+import { Store } from './simple-store';
+import { select$ } from './select$';
+
+describe('select$', () => {
+  it('should share data across replays', (done) => {
+    const item = {
+      title: 'Foo',
+      subtitle: 'Bar',
+    }
+    const store = new Store(item);
+    const title$ = select$(
+      store,
+      res => res.title,
+    );
+    title$.pipe(
+      take(1),
+    ).subscribe(title => {
+      expect(title).toEqual(item.title);
+    }, null, done);
+    title$.pipe(
+      take(1),
+    ).subscribe(title => {
+      expect(title).toEqual(item.title);
+    }, null, done);
+
+    // We expect no events to fire in the super class (BehaviorSubject)
+    // if the data remains the same.
+    const superSpy = spyOn(Object.getPrototypeOf(Object.getPrototypeOf(store)), 'next');
+    store.next(item);
+    expect(superSpy).toHaveBeenCalledTimes(0);
+    store.complete();
+  });
+});

--- a/src/app/modules/core/utils/select$.ts
+++ b/src/app/modules/core/utils/select$.ts
@@ -1,0 +1,25 @@
+import { naiveObjectComparison } from './simple-store';
+import { Observable } from 'rxjs';
+import { map, distinctUntilChanged, shareReplay } from 'rxjs/operators';
+
+type MappingFunction<T, R> = (mappable: T) => R;
+type MemoizationFunction<R> = (previousResult: R, currentResult: R) => boolean;
+
+function defaultMemoization(previousValue: any, currentValue: any): boolean {
+  if (typeof previousValue === 'object' && typeof currentValue === 'object') {
+    return naiveObjectComparison(previousValue, currentValue);
+  }
+  return previousValue === currentValue;
+}
+
+export function select$<T, R> (
+  source$: Observable<T>,
+  mappingFunction: MappingFunction<T, R>,
+  memoizationFunction?: MemoizationFunction<R>
+): Observable<R> {
+  return source$.pipe(
+    map(mappingFunction),
+    distinctUntilChanged(memoizationFunction || defaultMemoization),
+    shareReplay(1)
+  );
+}

--- a/src/app/modules/core/utils/simple-store.spec.ts
+++ b/src/app/modules/core/utils/simple-store.spec.ts
@@ -1,0 +1,36 @@
+import { Store } from './simple-store';
+
+describe('Store', () => {
+  it('should only fire an event over the behavior subject if data has changed', (done) => {
+    const item = {
+      title: 'Foo',
+      subtitle: 'Bar',
+    }
+    const store = new Store(item)
+    store.subscribe(res => {
+      expect(res).toEqual(item);
+    }, null, done);
+    store.subscribe(res => {
+      expect(res).toEqual(item);
+    }, null, done);
+    expect(store.observers.length).toEqual(2);
+
+    // We spy on the superclass 'next' method (BehaviorSubject).
+    const superSpy = spyOn(Object.getPrototypeOf(Object.getPrototypeOf(store)), 'next');
+    // We send the item over the store 2 times
+    // but expect 0 calls to the superclass next()
+    // method given the data has not changed.
+    store.next(item);
+    store.next(item);
+    expect(superSpy).toHaveBeenCalledTimes(0);
+
+    // Next, we change the item and fire again and now
+    // we should have seen the super class's next() method get called.
+    store.next({
+      title: 'Hello',
+      subtitle: 'World',
+    });
+    expect(superSpy).toHaveBeenCalledTimes(1);
+    store.complete();
+  });
+});

--- a/src/app/modules/core/utils/simple-store.ts
+++ b/src/app/modules/core/utils/simple-store.ts
@@ -1,0 +1,19 @@
+import { BehaviorSubject } from 'rxjs';
+import deepFreeze from './deep-freeze';
+
+export class Store<T> extends BehaviorSubject<T> {
+  constructor(initialData: T) {
+    super(deepFreeze(initialData));
+  }
+
+  next(newData: T): void {
+    const frozenData = deepFreeze(newData);
+    if (!naiveObjectComparison(frozenData, this.getValue())) {
+      super.next(frozenData);
+    }
+  }
+}
+
+export function naiveObjectComparison(objOne: any, objTwo: any): boolean {
+  return JSON.stringify(objOne) === JSON.stringify(objTwo);
+}

--- a/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.html
+++ b/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.html
@@ -1,10 +1,10 @@
-<mat-card class="bg-paper" *ngIf="(nodeConnection$ | async) as conn">
+<mat-card class="bg-paper">
   <div class="flex items-center">
     <div>
       <div
         class="pulsating-circle"
-        [class.green]="conn.connected"
-        [class.red]="!conn.connected"></div>
+        [class.green]="(connected$ | async)"
+        [class.red]="!(connected$ | async)"></div>
     </div>
     <div class="text-white text-lg m-0 ml-4">
       Beacon Node Status
@@ -12,20 +12,20 @@
   </div>
   <div class="my-4">
     <div class="text-muted text-lg">
-      {{conn.beaconNodeEndpoint}}
+      {{endpoint$ | async}}
     </div>
     <div
-      *ngIf="conn.connected"
+      *ngIf="(connected$ | async)"
       class="text-base my-2 text-success">
       Connected
     </div>
     <div
-      *ngIf="!conn.connected"
+      *ngIf="!(connected$ | async)"
       class="text-base my-2 text-error">
       Not Connected
     </div>
   </div>
-  <div *ngIf="conn.connected && conn.syncing">
+  <div *ngIf="(connected$ | async) && (syncing$ | async)">
     <div>
       <mat-progress-bar color="accent" mode="indeterminate"></mat-progress-bar>
     </div>

--- a/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.spec.ts
+++ b/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.spec.ts
@@ -13,11 +13,9 @@ describe('BeaconNodeStatusComponent', () => {
   let component: BeaconNodeStatusComponent;
   let fixture: ComponentFixture<BeaconNodeStatusComponent>;
   let service: BeaconNodeService = MockService(BeaconNodeService);
-  service.statusPoll$ = of({
-    beaconNodeEndpoint: 'endpoint.com',
-    connected: true,
-    syncing: true,
-  } as NodeConnectionResponse);
+  service.beaconNodeEndpoint$ = of('endpoint.com');
+  service.beaconNodeConnected$ = of(true);
+  service.beaconNodeSyncing$ = of(true);
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -36,18 +34,18 @@ describe('BeaconNodeStatusComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(BeaconNodeStatusComponent);
     component = fixture.componentInstance;
-    component.nodeConnection$ = service.statusPoll$;
+    component.endpoint$ = service.beaconNodeEndpoint$;
+    component.connected$ = service.beaconNodeConnected$;
+    component.syncing$ = service.beaconNodeSyncing$;
     fixture.detectChanges();
   });
 
   it('it should display different pulsating circles based on connection status', () => {
     let circle = fixture.debugElement.query(By.css('.pulsating-circle.green'));
     expect(circle.nativeElement).toBeTruthy();
-    component.nodeConnection$ = of({
-      beaconNodeEndpoint: 'endpoint.com',
-      connected: false,
-      syncing: true,
-    } as NodeConnectionResponse);
+    component.endpoint$ = of('endpoint.com');
+    component.connected$ = of(false);
+    component.syncing$ = of(true);
     fixture.detectChanges();
     circle = fixture.debugElement.query(By.css('.pulsating-circle.red'));
     expect(circle.nativeElement).toBeTruthy();
@@ -55,11 +53,9 @@ describe('BeaconNodeStatusComponent', () => {
 
   it('it should display different message based on connection status', () => {
     expect((fixture.nativeElement as HTMLElement).textContent).toContain('Connected');
-    component.nodeConnection$ = of({
-      beaconNodeEndpoint: 'endpoint.com',
-      connected: false,
-      syncing: true,
-    } as NodeConnectionResponse);
+    component.endpoint$ = of('endpoint.com');
+    component.connected$ = of(false);
+    component.syncing$ = of(true);
     fixture.detectChanges();
     expect((fixture.nativeElement as HTMLElement).textContent).toContain('Not Connected');
   });
@@ -68,11 +64,9 @@ describe('BeaconNodeStatusComponent', () => {
     let bar = fixture.debugElement.query(By.css('.mat-progress-bar'));
     expect(bar.nativeElement).toBeTruthy();
     expect((fixture.nativeElement as HTMLElement).textContent).toContain('Syncing to chain head');
-    component.nodeConnection$ = of({
-      beaconNodeEndpoint: 'endpoint.com',
-      connected: true,
-      syncing: false,
-    } as NodeConnectionResponse);
+    component.endpoint$ = of('endpoint.com');
+    component.connected$ = of(true);
+    component.syncing$ = of(false);
     fixture.detectChanges();
     bar = fixture.debugElement.query(By.css('.mat-progress-bar'));
     expect(bar).toBeNull();
@@ -80,11 +74,9 @@ describe('BeaconNodeStatusComponent', () => {
   });
 
   it('it should only display sync process bar if connected', () => {
-    component.nodeConnection$ = of({
-      beaconNodeEndpoint: 'endpoint.com',
-      connected: false,
-      syncing: true,
-    } as NodeConnectionResponse);
+    component.endpoint$ = of('endpoint.com');
+    component.connected$ = of(false);
+    component.syncing$ = of(true);
     fixture.detectChanges();
     const bar = fixture.debugElement.query(By.css('.mat-progress-bar'));
     expect(bar).toBeNull();

--- a/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.ts
+++ b/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.ts
@@ -9,5 +9,7 @@ import { BeaconNodeService } from 'src/app/modules/core/services/beacon-node.ser
 })
 export class BeaconNodeStatusComponent {
   constructor(private nodeService: BeaconNodeService) { }
-  nodeConnection$ = this.nodeService.statusPoll$;
+  connected$ = this.nodeService.beaconNodeConnected$;
+  syncing$ = this.nodeService.beaconNodeSyncing$;
+  endpoint$ = this.nodeService.beaconNodeEndpoint$;
 }

--- a/src/app/modules/dashboard/dashboard.component.spec.ts
+++ b/src/app/modules/dashboard/dashboard.component.spec.ts
@@ -1,20 +1,30 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { MockService } from 'ng-mocks';
+import { of } from 'rxjs';
+
 import { SharedModule } from '../../modules/shared/shared.module';
 import { SidebarExpandableLinkComponent } from './components/sidebar-expandable-link/sidebar-expandable-link.component';
 import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { DashboardComponent } from './dashboard.component';
+import { BeaconNodeService } from '../core/services/beacon-node.service';
+import { NodeConnectionResponse } from 'src/app/proto/validator/accounts/v2/web_api';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
+  let serviceMock = MockService(BeaconNodeService)
+  serviceMock.nodeStatusPoll$ = of({} as NodeConnectionResponse);
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
         SharedModule,
+      ],
+      providers: [
+        { provide: BeaconNodeService, useValue: serviceMock },
       ],
       declarations: [
         SidebarExpandableLinkComponent,

--- a/src/app/modules/dashboard/dashboard.component.ts
+++ b/src/app/modules/dashboard/dashboard.component.ts
@@ -72,7 +72,6 @@ export class DashboardComponent implements OnInit {
   
   ngOnInit(): void {
     this.beaconNodeService.nodeStatusPoll$.pipe(
-      tap((res) => console.log(res)),
       takeUntil(this.destroyed$$),
     ).subscribe();
   }

--- a/src/app/modules/dashboard/dashboard.component.ts
+++ b/src/app/modules/dashboard/dashboard.component.ts
@@ -1,11 +1,17 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import SidebarLink from './types/sidebar-link';
+import { BeaconNodeService } from '../core/services/beacon-node.service';
+import { Subject } from 'rxjs';
+import { takeUntil, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
 })
-export class DashboardComponent {
+export class DashboardComponent implements OnInit {
+  constructor(
+    private beaconNodeService: BeaconNodeService,
+  ) { }
   links: SidebarLink[] = [
     {
       name: 'Validator Gains & Losses',
@@ -61,4 +67,18 @@ export class DashboardComponent {
       externalUrl: 'https://docs.prylabs.network'
     },
   ];
+
+  destroyed$$ = new Subject<void>();
+  
+  ngOnInit(): void {
+    this.beaconNodeService.nodeStatusPoll$.pipe(
+      tap((res) => console.log(res)),
+      takeUntil(this.destroyed$$),
+    ).subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.destroyed$$.next();
+    this.destroyed$$.complete();
+  }
 }

--- a/src/app/modules/onboarding/validators/mnemonic.validator.spec.ts
+++ b/src/app/modules/onboarding/validators/mnemonic.validator.spec.ts
@@ -4,7 +4,6 @@ import { of, Observable } from 'rxjs';
 
 import { WalletService } from '../../core/services/wallet.service';
 import { MnemonicValidator } from './mnemonic.validator';
-import { expressionType } from '@angular/compiler/src/output/output_ast';
 
 describe('MnemonicValidator', () => {
   let walletService: jasmine.SpyObj<WalletService>;


### PR DESCRIPTION
# Summary

This PR adds a simple, immutable store that we can use in our services without needing to use advanced state management libraries such as [NgRx](https://ngrx.io/). The store relies on behavior subjects which fire only if data changed and can be shared across subscribers.

## The Problem

We have certain observables that will be called by multiple subscribers across the application, and we want to make this painless, prevent redundant http requests, and ensure data is kept in an immutable store to prevent modification. State management is a complex topic, and we want to avoid adding a more advanced library like NgRx if we can accomplish what we need with simple code.

## The Solution

The idea is to create a `Store` class which extends `BehaviorSubject` which (a) deeply freezes data to make it immutable and (b) only fires new events if the new data is different than the previous one

```js
export class Store<T> extends BehaviorSubject<T> {
  constructor(initialData: T) {
    super(deepFreeze(initialData));
  }

  next(newData: T): void {
    const frozenData = deepFreeze(newData);
    if (!objectComparison(frozenData, this.getValue())) {
      super.next(frozenData);
    }
  }
}
```

Moreover, we add a simple `select$` observable which can allow us to create shared access of fields of the data within a store as observables throughout the application:

```js
beaconNodeEndpoint$ = select$(
    this.beaconNodeState$,
    (res: NodeConnectionResponse) => res.beaconNodeEndpoint + BEACON_API_SUFFIX,
);
```
This observable will be shared across subscribers and will only fire if data has changed.