### PR TITLE
Fix for closing the nav menu on a small screen

### DIFF
--- a/src/app/modules/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/dashboard.component.html
@@ -1,5 +1,5 @@
 <mat-sidenav-container class="bg-default" [class.isSmallScreen]="isSmallScreen" [class.smallHidden]="isSmallScreen">
-  <mat-sidenav [mode]="isSmallScreen ? 'over' : 'side'" [opened]="isOpened" [fixedInViewport]="!isSmallScreen" (click)="isSmallScreen ? isOpened = !isOpened : isOpened = true" (openedChange)="openChanged($event)">
+  <mat-sidenav [mode]="isSmallScreen ? 'over' : 'side'" [opened]="isOpened" [fixedInViewport]="!isSmallScreen" (openedChange)="openChanged($event)">
     <app-sidebar [links]="links"></app-sidebar>
   </mat-sidenav>
   <mat-sidenav-content>

--- a/src/app/modules/dashboard/dashboard.component.ts
+++ b/src/app/modules/dashboard/dashboard.component.ts
@@ -2,8 +2,9 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import SidebarLink from './types/sidebar-link';
 import { BeaconNodeService } from '../core/services/beacon-node.service';
 import { Subject } from 'rxjs';
-import { takeUntil, tap } from 'rxjs/operators';
+import { take, takeUntil, tap } from 'rxjs/operators';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-dashboard',
@@ -13,7 +14,15 @@ export class DashboardComponent implements OnInit, OnDestroy {
   constructor(
     private beaconNodeService: BeaconNodeService,
     private breakpointObserver: BreakpointObserver,
-  ) { }
+    private router: Router) {
+    router.events.pipe(
+      takeUntil(this.destroyed$$)
+    ).subscribe((val) => {
+      if (this.isSmallScreen) {
+        this.isOpened = false;
+      }
+    });
+  }
   links: SidebarLink[] = [
     {
       name: 'Validator Gains & Losses',


### PR DESCRIPTION
Problem: When clicking on the nav menu (on a small screen) to open a sub menu the nav bar closes.

Fix:  The nav menu on a small screen is now only closed if the routing changes or if you click outside the nav bar.