### PR TITLE
Cleanups, Miscellaneous Fixes, and CreateAccount functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4422,8 +4422,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -7012,8 +7011,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -7574,8 +7572,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "4.0.6",
@@ -7892,7 +7889,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
       "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
-      "dev": true,
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -8251,7 +8247,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -9843,8 +9838,7 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -10835,8 +10829,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -11658,7 +11651,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -12150,8 +12142,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -12491,8 +12482,7 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.1",
@@ -13278,7 +13268,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -14343,8 +14332,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-promisify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "echarts": "^4.8.0",
     "ethers": "^5.0.12",
     "file-saver": "^2.0.2",
+    "jszip": "^3.5.0",
     "moment": "^2.27.0",
     "ngx-echarts": "^5.1.2",
     "ngx-file-drop": "^9.0.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,7 +37,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
-    { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
+    // { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
     { provide: ENVIRONMENT, useValue: environment },
   ],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,7 +37,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
-    // { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
     { provide: ENVIRONMENT, useValue: environment },
   ],
   bootstrap: [AppComponent]

--- a/src/app/modules/auth/login/login.component.html
+++ b/src/app/modules/auth/login/login.component.html
@@ -24,7 +24,7 @@
             </div>
             <div class="flex">
               <div class="btn-container">
-                <button mat-raised-button color="primary" name="submit" [disabled]="loading || loginForm.invalid">Sign in to dashboard</button>
+                <button mat-raised-button color="primary" name="submit" [disabled]="loading">Sign in to dashboard</button>
                 <div class="btn-progress" *ngIf="loading">
                   <mat-spinner color="primary" [diameter]="25"></mat-spinner>
                 </div>

--- a/src/app/modules/auth/login/login.component.ts
+++ b/src/app/modules/auth/login/login.component.ts
@@ -50,6 +50,10 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   onSubmit(): void {
     this.submitted = true;
+    this.loginForm.markAllAsTouched();
+    if (this.loginForm.invalid) {
+      return;
+    }
     const password = this.loginForm.get('password')?.value as string;
     this.loading = true;
     this.authService.login(password).pipe(

--- a/src/app/modules/core/guards/authredirect.guard.ts
+++ b/src/app/modules/core/guards/authredirect.guard.ts
@@ -24,7 +24,7 @@ export class AuthredirectGuard implements CanActivate {
     state: RouterStateSnapshot
   ): Observable<any> | Promise<boolean|UrlTree> | boolean{
     if (this.authenticationService.token) {
-      this.router.navigate(['/dashboard/wallet/accounts']);
+      this.router.navigate(['/dashboard/gains-and-losses']);
       return false;
     }
     return true;

--- a/src/app/modules/core/guards/authredirect.guard.ts
+++ b/src/app/modules/core/guards/authredirect.guard.ts
@@ -24,7 +24,7 @@ export class AuthredirectGuard implements CanActivate {
     state: RouterStateSnapshot
   ): Observable<any> | Promise<boolean|UrlTree> | boolean{
     if (this.authenticationService.token) {
-      this.router.navigate(['/dashboard/gains-and-losses']);
+      this.router.navigate(['/dashboard/wallet/accounts']);
       return false;
     }
     return true;

--- a/src/app/modules/core/mocks/index.ts
+++ b/src/app/modules/core/mocks/index.ts
@@ -6,7 +6,6 @@ import {
   ListAccountsResponse,
   Account,
   HasWalletResponse,
-  KeymanagerKind,
   ImportKeystoresResponse,
   BackupAccountsResponse,
   DeleteAccountsResponse
@@ -74,12 +73,12 @@ export const Mocks: IMocks = {
   } as HasWalletResponse,
   '/v2/validator/wallet': {
     keymanagerConfig: { direct_eip_version: 'EIP-2335' },
-    keymanagerKind: KeymanagerKind.DIRECT,
+    keymanagerKind: 'DIRECT',
     walletPath: '/Users/erinlindford/Library/Eth2Validators/prysm-wallet-v2'
   } as WalletResponse,
   '/v2/validator/wallet/create': {
     walletPath: '/Users/johndoe/Library/Eth2Validators/prysm-wallet-v2',
-    keymanagerKind: KeymanagerKind.DERIVED,
+    keymanagerKind: 'DERIVED',
   } as WalletResponse,
   '/v2/validator/wallet/keystores/import': {
     importedPublicKeys: mockImportedKeys,
@@ -212,9 +211,9 @@ export const Mocks: IMocks = {
         validator: {
           publicKey: key,
           effectiveBalance: '31200823019',
-          activationEpoch: 1000,
+          activationEpoch: '1000',
           slashed: false,
-          exitEpoch: 23020302,
+          exitEpoch: '23020302',
         },
       } as Validators_ValidatorContainer;
     }),

--- a/src/app/modules/core/services/error.service.ts
+++ b/src/app/modules/core/services/error.service.ts
@@ -19,7 +19,7 @@ export class ErrorService {
           formattedError = 'Bad gateway, cannot connect to server';
           break;
         case 503:
-          formattedError = 'Server unavailable, cannot connect to server';
+          formattedError = 'Server unavailable, perhaps node is still syncing';
           break;
         case 504:
           formattedError = 'Operation timed out, perhaps the server is down';

--- a/src/app/modules/core/services/validator.service.spec.ts
+++ b/src/app/modules/core/services/validator.service.spec.ts
@@ -1,69 +1,69 @@
-import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+// import { TestBed } from '@angular/core/testing';
+// import { HttpClientTestingModule } from '@angular/common/http/testing';
 
-import { MockService } from 'ng-mocks';
+// import { MockService } from 'ng-mocks';
 
-import { ValidatorService, MAX_EPOCH_LOOKBACK } from './validator.service';
-import { BeaconNodeService } from './beacon-node.service';
-import { WalletService } from './wallet.service';
-import { of } from 'rxjs';
-import { ValidatorBalances, ValidatorBalances_Balance } from 'src/app/proto/eth/v1alpha1/beacon_chain';
-import { hexToBase64 } from '../utils/hex-util';
+// import { ValidatorService, MAX_EPOCH_LOOKBACK } from './validator.service';
+// import { BeaconNodeService } from './beacon-node.service';
+// import { WalletService } from './wallet.service';
+// import { of } from 'rxjs';
+// import { ValidatorBalances, ValidatorBalances_Balance } from 'src/app/proto/eth/v1alpha1/beacon_chain';
+// import { hexToBase64 } from '../utils/hex-util';
 
-describe('ValidatorService', () => {
-  let service: ValidatorService;
-  let beaconNodeService: BeaconNodeService = MockService(BeaconNodeService);
-  let walletService: WalletService = MockService(WalletService);
-  (beaconNodeService as any)['nodeEndpoint$'] = of('endpoint');
-  walletService['validatingPublicKeys$'] = of([] as string[]);
+// describe('ValidatorService', () => {
+//   let service: ValidatorService;
+//   let beaconNodeService: BeaconNodeService = MockService(BeaconNodeService);
+//   let walletService: WalletService = MockService(WalletService);
+//   (beaconNodeService as any)['nodeEndpoint$'] = of('endpoint');
+//   walletService['validatingPublicKeys$'] = of([] as string[]);
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule,
-      ],
-      providers: [
-        { provide: BeaconNodeService, useValue: beaconNodeService },
-        { provide: WalletService, useValue: walletService },
-      ]
-    });
-    service = TestBed.inject(ValidatorService);
-    beaconNodeService = TestBed.inject(BeaconNodeService);
-    walletService = TestBed.inject(WalletService);
-    spyOn(service, 'balancesByEpoch').and.returnValue(of({
-      epoch: 0,
-      balances: [
-        {
-          publicKey: hexToBase64('0x1234'),
-          balance: '31200823019',
-        },
-      ] as ValidatorBalances_Balance[],
-    } as ValidatorBalances));
-  });
+//   beforeEach(() => {
+//     TestBed.configureTestingModule({
+//       imports: [
+//         HttpClientTestingModule,
+//       ],
+//       providers: [
+//         { provide: BeaconNodeService, useValue: beaconNodeService },
+//         { provide: WalletService, useValue: walletService },
+//       ]
+//     });
+//     service = TestBed.inject(ValidatorService);
+//     beaconNodeService = TestBed.inject(BeaconNodeService);
+//     walletService = TestBed.inject(WalletService);
+//     spyOn(service, 'balancesByEpoch').and.returnValue(of({
+//       epoch: 0,
+//       balances: [
+//         {
+//           publicKey: hexToBase64('0x1234'),
+//           balance: '31200823019',
+//         },
+//       ] as ValidatorBalances_Balance[],
+//     } as ValidatorBalances));
+//   });
 
-  describe('recentEpochBalances', () => {
-    it('should disallow lookback > MAX_EPOCH_LOOKBACK', () => {
-      const badCall = () => {
-        service.recentEpochBalances(0, MAX_EPOCH_LOOKBACK + 1, 5);
-      };
-      expect(badCall).toThrowError();
-    });
+//   describe('recentEpochBalances', () => {
+//     it('should disallow lookback > MAX_EPOCH_LOOKBACK', () => {
+//       const badCall = () => {
+//         service.recentEpochBalances(0, MAX_EPOCH_LOOKBACK + 1, 5);
+//       };
+//       expect(badCall).toThrowError();
+//     });
 
-    it('should return an array of length lookback items', done => {
-      service.recentEpochBalances(MAX_EPOCH_LOOKBACK + 5, MAX_EPOCH_LOOKBACK, 5).subscribe((result: ValidatorBalances[]) => {
-        expect(result).toBeTruthy();
-        expect(result.length).toEqual(5);
-        expect(result[0].epoch).toEqual(0);
-        done();
-      });
-    });
-  });
+//     it('should return an array of length lookback items', done => {
+//       service.recentEpochBalances(MAX_EPOCH_LOOKBACK + 5, MAX_EPOCH_LOOKBACK, 5).subscribe((result: ValidatorBalances[]) => {
+//         expect(result).toBeTruthy();
+//         expect(result.length).toEqual(5);
+//         expect(result[0].epoch).toEqual(0);
+//         done();
+//       });
+//     });
+//   });
 
-  describe('balancesByEpoch', () => {
-    it('should properly encode a public key for URI inclusion', () => {
-      const key = hexToBase64('0x1234');
-      const encoded = (service as any).encodePublicKey(key);
-      expect(decodeURIComponent(encoded)).toEqual(key.toString());
-    });
-  });
-});
+//   describe('balancesByEpoch', () => {
+//     it('should properly encode a public key for URI inclusion', () => {
+//       const key = hexToBase64('0x1234');
+//       const encoded = (service as any).encodePublicKey(key);
+//       expect(decodeURIComponent(encoded)).toEqual(key.toString());
+//     });
+//   });
+// });

--- a/src/app/modules/core/services/validator.service.spec.ts
+++ b/src/app/modules/core/services/validator.service.spec.ts
@@ -9,13 +9,13 @@ import { WalletService } from './wallet.service';
 import { of } from 'rxjs';
 import { ValidatorBalances, ValidatorBalances_Balance } from 'src/app/proto/eth/v1alpha1/beacon_chain';
 import { hexToBase64 } from '../utils/hex-util';
+import { Account, ListAccountsResponse } from 'src/app/proto/validator/accounts/v2/web_api';
 
 describe('ValidatorService', () => {
   let service: ValidatorService;
   let beaconNodeService: BeaconNodeService = MockService(BeaconNodeService);
   let walletService: WalletService = MockService(WalletService);
   (beaconNodeService as any)['nodeEndpoint$'] = of('endpoint');
-  walletService['validatingPublicKeys$'] = of([] as string[]);
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -30,6 +30,9 @@ describe('ValidatorService', () => {
     service = TestBed.inject(ValidatorService);
     beaconNodeService = TestBed.inject(BeaconNodeService);
     walletService = TestBed.inject(WalletService);
+    spyOn(walletService, 'accounts').and.returnValue(of({
+      accounts: [] as Account[],
+    } as ListAccountsResponse));
     spyOn(service, 'balancesByEpoch').and.returnValue(of({
       epoch: 0,
       balances: [

--- a/src/app/modules/core/services/validator.service.spec.ts
+++ b/src/app/modules/core/services/validator.service.spec.ts
@@ -1,69 +1,69 @@
-// import { TestBed } from '@angular/core/testing';
-// import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
-// import { MockService } from 'ng-mocks';
+import { MockService } from 'ng-mocks';
 
-// import { ValidatorService, MAX_EPOCH_LOOKBACK } from './validator.service';
-// import { BeaconNodeService } from './beacon-node.service';
-// import { WalletService } from './wallet.service';
-// import { of } from 'rxjs';
-// import { ValidatorBalances, ValidatorBalances_Balance } from 'src/app/proto/eth/v1alpha1/beacon_chain';
-// import { hexToBase64 } from '../utils/hex-util';
+import { ValidatorService, MAX_EPOCH_LOOKBACK } from './validator.service';
+import { BeaconNodeService } from './beacon-node.service';
+import { WalletService } from './wallet.service';
+import { of } from 'rxjs';
+import { ValidatorBalances, ValidatorBalances_Balance } from 'src/app/proto/eth/v1alpha1/beacon_chain';
+import { hexToBase64 } from '../utils/hex-util';
 
-// describe('ValidatorService', () => {
-//   let service: ValidatorService;
-//   let beaconNodeService: BeaconNodeService = MockService(BeaconNodeService);
-//   let walletService: WalletService = MockService(WalletService);
-//   (beaconNodeService as any)['nodeEndpoint$'] = of('endpoint');
-//   walletService['validatingPublicKeys$'] = of([] as string[]);
+describe('ValidatorService', () => {
+  let service: ValidatorService;
+  let beaconNodeService: BeaconNodeService = MockService(BeaconNodeService);
+  let walletService: WalletService = MockService(WalletService);
+  (beaconNodeService as any)['nodeEndpoint$'] = of('endpoint');
+  walletService['validatingPublicKeys$'] = of([] as string[]);
 
-//   beforeEach(() => {
-//     TestBed.configureTestingModule({
-//       imports: [
-//         HttpClientTestingModule,
-//       ],
-//       providers: [
-//         { provide: BeaconNodeService, useValue: beaconNodeService },
-//         { provide: WalletService, useValue: walletService },
-//       ]
-//     });
-//     service = TestBed.inject(ValidatorService);
-//     beaconNodeService = TestBed.inject(BeaconNodeService);
-//     walletService = TestBed.inject(WalletService);
-//     spyOn(service, 'balancesByEpoch').and.returnValue(of({
-//       epoch: 0,
-//       balances: [
-//         {
-//           publicKey: hexToBase64('0x1234'),
-//           balance: '31200823019',
-//         },
-//       ] as ValidatorBalances_Balance[],
-//     } as ValidatorBalances));
-//   });
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+      ],
+      providers: [
+        { provide: BeaconNodeService, useValue: beaconNodeService },
+        { provide: WalletService, useValue: walletService },
+      ]
+    });
+    service = TestBed.inject(ValidatorService);
+    beaconNodeService = TestBed.inject(BeaconNodeService);
+    walletService = TestBed.inject(WalletService);
+    spyOn(service, 'balancesByEpoch').and.returnValue(of({
+      epoch: 0,
+      balances: [
+        {
+          publicKey: hexToBase64('0x1234'),
+          balance: '31200823019',
+        },
+      ] as ValidatorBalances_Balance[],
+    } as ValidatorBalances));
+  });
 
-//   describe('recentEpochBalances', () => {
-//     it('should disallow lookback > MAX_EPOCH_LOOKBACK', () => {
-//       const badCall = () => {
-//         service.recentEpochBalances(0, MAX_EPOCH_LOOKBACK + 1, 5);
-//       };
-//       expect(badCall).toThrowError();
-//     });
+  describe('recentEpochBalances', () => {
+    it('should disallow lookback > MAX_EPOCH_LOOKBACK', () => {
+      const badCall = () => {
+        service.recentEpochBalances(0, MAX_EPOCH_LOOKBACK + 1, 5);
+      };
+      expect(badCall).toThrowError();
+    });
 
-//     it('should return an array of length lookback items', done => {
-//       service.recentEpochBalances(MAX_EPOCH_LOOKBACK + 5, MAX_EPOCH_LOOKBACK, 5).subscribe((result: ValidatorBalances[]) => {
-//         expect(result).toBeTruthy();
-//         expect(result.length).toEqual(5);
-//         expect(result[0].epoch).toEqual(0);
-//         done();
-//       });
-//     });
-//   });
+    it('should return an array of length lookback items', done => {
+      service.recentEpochBalances(MAX_EPOCH_LOOKBACK + 5, MAX_EPOCH_LOOKBACK, 5).subscribe((result: ValidatorBalances[]) => {
+        expect(result).toBeTruthy();
+        expect(result.length).toEqual(5);
+        expect(result[0].epoch).toEqual(0);
+        done();
+      });
+    });
+  });
 
-//   describe('balancesByEpoch', () => {
-//     it('should properly encode a public key for URI inclusion', () => {
-//       const key = hexToBase64('0x1234');
-//       const encoded = (service as any).encodePublicKey(key);
-//       expect(decodeURIComponent(encoded)).toEqual(key.toString());
-//     });
-//   });
-// });
+  describe('balancesByEpoch', () => {
+    it('should properly encode a public key for URI inclusion', () => {
+      const key = hexToBase64('0x1234');
+      const encoded = (service as any).encodePublicKey(key);
+      expect(decodeURIComponent(encoded)).toEqual(key.toString());
+    });
+  });
+});

--- a/src/app/modules/core/services/validator.service.spec.ts
+++ b/src/app/modules/core/services/validator.service.spec.ts
@@ -44,13 +44,13 @@ describe('ValidatorService', () => {
   describe('recentEpochBalances', () => {
     it('should disallow lookback > MAX_EPOCH_LOOKBACK', () => {
       const badCall = () => {
-        service.recentEpochBalances(0, MAX_EPOCH_LOOKBACK + 1);
+        service.recentEpochBalances(0, MAX_EPOCH_LOOKBACK + 1, 5);
       };
       expect(badCall).toThrowError();
     });
 
     it('should return an array of length lookback items', done => {
-      service.recentEpochBalances(MAX_EPOCH_LOOKBACK + 5, MAX_EPOCH_LOOKBACK).subscribe((result: ValidatorBalances[]) => {
+      service.recentEpochBalances(MAX_EPOCH_LOOKBACK + 5, MAX_EPOCH_LOOKBACK, 5).subscribe((result: ValidatorBalances[]) => {
         expect(result).toBeTruthy();
         expect(result.length).toEqual(5);
         expect(result[0].epoch).toEqual(0);

--- a/src/app/modules/core/services/validator.service.ts
+++ b/src/app/modules/core/services/validator.service.ts
@@ -111,20 +111,6 @@ export class ValidatorService {
     );
   }
 
-  validatorListForPubKeys(
-    publicKeys: string[],
-  ): Observable<Validators> {
-    let params = `?publicKeys=`;
-    publicKeys.forEach((key, _) => {
-      params += `${this.encodePublicKey(key)}&publicKeys=`;
-    });
-    return this.beaconNodeService.nodeEndpoint$.pipe(
-      switchMap((endpoint: string) => {
-        return this.http.get<Validators>(`${endpoint}/validators${params}`);
-      }),
-    );
-  }
-
   balances(
     publicKeys: string[],
     pageIndex: number,
@@ -133,20 +119,6 @@ export class ValidatorService {
     return this.beaconNodeService.nodeEndpoint$.pipe(
       switchMap((endpoint: string) => {
         const params = this.formatURIParameters(publicKeys, pageIndex, pageSize);
-        return this.http.get<ValidatorBalances>(`${endpoint}/validators/balances${params}`);
-      }),
-    );
-  }
-
-  balancesForPubKeys(
-    publicKeys: string[],
-  ): Observable<ValidatorBalances> {
-    let params = `?publicKeys=`;
-    publicKeys.forEach((key, _) => {
-      params += `${this.encodePublicKey(key)}&publicKeys=`;
-    });
-    return this.beaconNodeService.nodeEndpoint$.pipe(
-      switchMap((endpoint: string) => {
         return this.http.get<ValidatorBalances>(`${endpoint}/validators/balances${params}`);
       }),
     );

--- a/src/app/modules/core/services/wallet.service.spec.ts
+++ b/src/app/modules/core/services/wallet.service.spec.ts
@@ -4,7 +4,6 @@ import { WalletService } from './wallet.service';
 import {
   GenerateMnemonicResponse,
   WalletResponse,
-  KeymanagerKind,
   CreateWalletRequest,
 } from 'src/app/proto/validator/accounts/v2/web_api';
 import { EnvironmenterService } from './environmenter.service';
@@ -60,7 +59,7 @@ describe('WalletService', () => {
         walletPath: '/home/ubuntu/.eth2validators/prysm-wallet-v2',
       } as WalletResponse;
       const request = {
-        keymanager: KeymanagerKind.DERIVED,
+        keymanager: 'DERIVED',
         walletPassword: 'password',
         numAccounts: 4,
       } as CreateWalletRequest;

--- a/src/app/modules/core/services/wallet.service.ts
+++ b/src/app/modules/core/services/wallet.service.ts
@@ -37,10 +37,9 @@ export class WalletService {
   walletConfig$: Observable<WalletResponse> = this.http.get<WalletResponse>(`${this.apiUrl}/wallet`).pipe(
     share(),
   );
-  accounts$: Observable<ListAccountsResponse> = this.http.get<ListAccountsResponse>(`${this.apiUrl}/accounts`).pipe(
-    share(),
-  );
-  validatingPublicKeys$: Observable<string[]> = this.accounts$.pipe(
+  validatingPublicKeys$: Observable<string[]> = this.http.get<ListAccountsResponse>(
+    `${this.apiUrl}/accounts?all=true`
+  ).pipe(
     map((res: ListAccountsResponse) => res.accounts.map((acc: Account) => acc.validatingPublicKey)),
     share(),
   );
@@ -53,6 +52,22 @@ export class WalletService {
     map((resp: GenerateMnemonicResponse) => resp.mnemonic),
     shareReplay(1),
   );
+
+  accounts(
+    pageIndex?: number,
+    pageSize?: number,
+  ): Observable<ListAccountsResponse> {
+    let params = `?`;
+    if (pageIndex) {
+      params += `pageToken=${pageIndex}&`;
+    }
+    if (pageSize) {
+      params += `pageSize=${pageSize}`;
+    }
+    return this.http.get<ListAccountsResponse>(`${this.apiUrl}/accounts${params}`).pipe(
+      share(),
+    );
+  }
 
   createWallet(request: CreateWalletRequest): Observable<WalletResponse> {
     return this.http.post<WalletResponse>(`${this.apiUrl}/wallet/create`, request);

--- a/src/app/modules/core/services/wallet.service.ts
+++ b/src/app/modules/core/services/wallet.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { map, shareReplay } from 'rxjs/operators';
+import { map, share, shareReplay } from 'rxjs/operators';
 import { EnvironmenterService } from './environmenter.service';
 import {
   WalletResponse,
@@ -17,6 +17,8 @@ import {
   BackupAccountsResponse,
   DeleteAccountsRequest,
   DeleteAccountsResponse,
+  CreateAccountsRequest,
+  DepositDataResponse
 } from 'src/app/proto/validator/accounts/v2/web_api';
 
 @Injectable({
@@ -32,13 +34,15 @@ export class WalletService {
 
   // Observables.
   walletExists$: Observable<HasWalletResponse> = this.http.get<HasWalletResponse>(`${this.apiUrl}/wallet/exists`);
-  walletConfig$: Observable<WalletResponse> = this.http.get<WalletResponse>(`${this.apiUrl}/wallet`);
+  walletConfig$: Observable<WalletResponse> = this.http.get<WalletResponse>(`${this.apiUrl}/wallet`).pipe(
+    share(),
+  );
   accounts$: Observable<ListAccountsResponse> = this.http.get<ListAccountsResponse>(`${this.apiUrl}/accounts`).pipe(
-    shareReplay(1),
+    share(),
   );
   validatingPublicKeys$: Observable<string[]> = this.accounts$.pipe(
     map((res: ListAccountsResponse) => res.accounts.map((acc: Account) => acc.validatingPublicKey)),
-    shareReplay(1),
+    share(),
   );
 
   // Retrieve a randomly generateed bip39 mnemonic from the backend,
@@ -60,6 +64,10 @@ export class WalletService {
 
   importKeystores(request: ImportKeystoresRequest): Observable<ImportKeystoresResponse> {
     return this.http.post<ImportKeystoresResponse>(`${this.apiUrl}/wallet/keystores/import`, request);
+  }
+
+  createAccounts(request: CreateAccountsRequest): Observable<DepositDataResponse> {
+    return this.http.post<DepositDataResponse>(`${this.apiUrl}/wallet/accounts/create`, request);
   }
 
   backupAccounts(request: BackupAccountsRequest): Observable<BackupAccountsResponse> {

--- a/src/app/modules/core/utils/hex-util.ts
+++ b/src/app/modules/core/utils/hex-util.ts
@@ -1,23 +1,28 @@
 export function hexToBase64(hexstring: string): string {
-  const hexArray = hexstring
-    .replace(/\r|\n/g, '')
-    .replace(/([\da-fA-F]{2}) ?/g, '0x$1 ')
-    .replace(/ +$/, '')
-    .split(' ')
-    .map(s => Number(s));
-  const byteString = String.fromCharCode.apply(null, hexArray);
-  return btoa(byteString);
+  if (!hexstring) {
+    return '';
+  }
+  let str = hexstring;
+  if (str.indexOf('0x') !== -1) {
+    str = str.replace('0x', '');
+  }
+  const matched = str.match(/.{2}/g);
+  if (!matched) {
+    return '';
+  }
+  const res = matched.map(c => parseInt(c, 16));
+  return btoa(
+    String.fromCharCode(
+      ...res,
+    )
+  );
 }
 
 export function base64ToHex(base64string: string): string {
-  const bin = atob(base64string.replace(/[ \r\n]+$/, ''));
-  const hex = [];
-  for (let i = 0; i < bin.length; ++i) {
-      let tmp = bin.charCodeAt(i).toString(16);
-      if (tmp.length === 1) {
-        tmp = '0' + tmp;
-      }
-      hex[hex.length] = tmp;
-  }
-  return '0x' + hex.join('');
+  const res = Array.prototype.reduce.call(
+    atob(base64string),
+    (acc, c) => acc + `0${c.charCodeAt(0).toString(16)}`.slice(-2),
+    ''
+  );
+  return '0x' + res;
 }

--- a/src/app/modules/dashboard/components/sidebar/sidebar.component.html
+++ b/src/app/modules/dashboard/components/sidebar/sidebar.component.html
@@ -3,7 +3,7 @@
     <div class="brand-area">
       <div class="flex items-center justify-center brand">
         <img src="https://prysmaticlabs.com/assets/Prysm.svg" alt="company-logo"/>
-        <span class="brand__text">Prysm Validator</span>
+        <span class="brand__text">Prysm Web</span>
       </div>
     </div>
     <div class="scrollbar-container scrollable position-relative ps">

--- a/src/app/modules/dashboard/components/validator-performance-summary/validator-performance-summary.component.ts
+++ b/src/app/modules/dashboard/components/validator-performance-summary/validator-performance-summary.component.ts
@@ -65,8 +65,12 @@ export class ValidatorPerformanceSummaryComponent {
     const averageEffectiveBalance = this.computeAverageEffectiveBalance(
       perf.currentEffectiveBalances
     );
-    const votedHeadPercentage = perf.correctlyVotedHead.filter(Boolean).length /
-      perf.correctlyVotedHead.length;
+    const totalVotedHead = perf.correctlyVotedHead.filter(Boolean).length;
+    let votedHeadPercentage = 0;
+    if (totalVotedHead) {
+      votedHeadPercentage = perf.correctlyVotedHead.filter(Boolean).length /
+        perf.correctlyVotedHead.length;
+    }
 
     const averageInclusionDistance = perf.inclusionDistances.reduce((prev, curr) => {
       if (curr.toString() === FAR_FUTURE_EPOCH) {
@@ -81,6 +85,8 @@ export class ValidatorPerformanceSummaryComponent {
       overallScore = 'Great';
     } else if (votedHeadPercentage >= 0.80) {
       overallScore = 'Good';
+    } else if (votedHeadPercentage === 0) {
+      overallScore = 'N/A';
     } else {
       overallScore = 'Poor';
     }
@@ -97,6 +103,9 @@ export class ValidatorPerformanceSummaryComponent {
   private computeAverageEffectiveBalance(balances: string[]): number {
     const effBalances = balances.map(num => BigNumber.from(num));
     const total = effBalances.reduce((prev, curr) => prev.add(curr), BigNumber.from('0'));
+    if (total.eq(BigNumber.from('0'))) {
+      return 0;
+    }
     return total.div(BigNumber.from(balances.length)).div(GWEI_PER_ETHER).toNumber();
   }
 
@@ -110,6 +119,9 @@ export class ValidatorPerformanceSummaryComponent {
       return num.sub(beforeTransition[idx]);
     });
     const gainsInGwei = diffInEth.reduce((prev, curr) => prev.add(curr), BigNumber.from('0'));
+    if (gainsInGwei.eq(BigNumber.from('0'))) {
+      return 0;
+    }
     return gainsInGwei.toNumber() / GWEI_PER_ETHER;
   }
 }

--- a/src/app/modules/dashboard/pages/gains-and-losses/gains-and-losses.component.html
+++ b/src/app/modules/dashboard/pages/gains-and-losses/gains-and-losses.component.html
@@ -34,9 +34,9 @@
       <div class="py-4"></div>
       <mat-card class="bg-primary">
         <p class="m-0 text-muted text-base leading-snug">
-          Want to monitor your system process such as memory/cpu usage and more? Our metrics page has you covered
+          Want to monitor your system process such as logs from your beacon node and validator? Our logs page has you covered
         </p>
-        <a routerLink="/dashboard/system/metrics"><button mat-stroked-button>View Metrics</button></a>
+        <a routerLink="/dashboard/system/logs"><button mat-stroked-button>View Logs</button></a>
       </mat-card>
       <div class="py-4"></div>
       <app-activation-queue></app-activation-queue>

--- a/src/app/modules/dashboard/pages/gains-and-losses/gains-and-losses.component.html
+++ b/src/app/modules/dashboard/pages/gains-and-losses/gains-and-losses.component.html
@@ -6,10 +6,10 @@
         <div class="welcome-card flex justify-between px-4 pt-4">
           <div class="pr-12">
             <div class="text-2xl mb-4 text-white leading-snug">
-              Your Prysm validator dashboard
+              Your Prysm web dashboard
             </div>
             <p class="m-0 text-muted text-base leading-snug">
-              Manage your Prysm validator, analyze your validator performance, and control your wallet all from a simple web interface
+              Manage your Prysm validator and beacon node, analyze your validator performance, and control your wallet all from a simple web interface
             </p>
           </div>
           <img

--- a/src/app/modules/dashboard/pages/gains-and-losses/gains-and-losses.component.ts
+++ b/src/app/modules/dashboard/pages/gains-and-losses/gains-and-losses.component.ts
@@ -22,7 +22,9 @@ export class GainsAndLossesComponent implements OnInit {
   ngOnInit(): void {
     this.beaconService.chainHead$.pipe(
       switchMap((head: ChainHead) =>
-        this.validatorService.recentEpochBalances(head.headEpoch, 3 /* lookback */)
+        this.validatorService.recentEpochBalances(
+          head.headEpoch, 3 /* lookback */, 10 /* num accounts */,
+        )
       ),
       take(1),
       tap((res) => console.log(res)),

--- a/src/app/modules/onboarding/components/confirm-mnemonic/confirm-mnemonic.component.html
+++ b/src/app/modules/onboarding/components/confirm-mnemonic/confirm-mnemonic.component.html
@@ -10,7 +10,6 @@
     <textarea matInput
       name="mnemonic"
       formControlName="mnemonic"
-      appBlockCopyPaste
       cdkTextareaAutosize
       #autosize="cdkTextareaAutosize"
       cdkAutosizeMinRows="3"

--- a/src/app/modules/onboarding/pages/hd-wallet-wizard/hd-wallet-wizard.component.ts
+++ b/src/app/modules/onboarding/pages/hd-wallet-wizard/hd-wallet-wizard.component.ts
@@ -11,7 +11,7 @@ import { AuthenticationService } from 'src/app/modules/core/services/authenticat
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
 import { MnemonicValidator } from '../../validators/mnemonic.validator';
 import { PasswordValidator } from 'src/app/modules/core/validators/password.validator';
-import { CreateWalletRequest, KeymanagerKind } from 'src/app/proto/validator/accounts/v2/web_api';
+import { CreateWalletRequest } from 'src/app/proto/validator/accounts/v2/web_api';
 
 enum WizardState {
   Overview,
@@ -117,7 +117,7 @@ export class HdWalletWizardComponent implements OnInit, OnDestroy {
   createWallet(event: Event): void {
     event.stopPropagation();
     const request = {
-      keymanager: KeymanagerKind.DERIVED,
+      keymanager: 'DERIVED',
       walletPassword: this.passwordFormGroup.controls.password.value,
       numAccounts: this.accountsFormGroup.controls.numAccounts.value,
       mnemonic: this.mnemonicFormGroup.controls.mnemonic.value,

--- a/src/app/modules/onboarding/pages/nonhd-wallet-wizard/nonhd-wallet-wizard.component.ts
+++ b/src/app/modules/onboarding/pages/nonhd-wallet-wizard/nonhd-wallet-wizard.component.ts
@@ -10,7 +10,7 @@ import { Subject, throwError } from 'rxjs';
 import { PasswordValidator } from 'src/app/modules/core/validators/password.validator';
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
 import { AuthenticationService } from 'src/app/modules/core/services/authentication.service';
-import { CreateWalletRequest, KeymanagerKind } from 'src/app/proto/validator/accounts/v2/web_api';
+import { CreateWalletRequest } from 'src/app/proto/validator/accounts/v2/web_api';
 import { MAX_ALLOWED_KEYSTORES } from 'src/app/modules/core/constants';
 
 enum WizardState {
@@ -120,7 +120,7 @@ export class NonhdWalletWizardComponent implements OnInit, OnDestroy {
   createWallet(event: Event): void {
     event.stopPropagation();
     const request = {
-      keymanager: KeymanagerKind.DIRECT,
+      keymanager: 'DIRECT',
       walletPassword: this.passwordFormGroup.get('password')?.value,
       keystoresPassword: this.unlockFormGroup.get('keystoresPassword')?.value,
       keystoresImported: this.importFormGroup.get('keystoresImported')?.value,

--- a/src/app/modules/shared/components/breadcrumb/breadcrumb.component.html
+++ b/src/app/modules/shared/components/breadcrumb/breadcrumb.component.html
@@ -1,5 +1,5 @@
 <nav class="flex items-center position-relative mb-8 mt-1" *ngIf="(breadcrumbs$ | async) as breadcrumbs">
-  <a routerLink="/dashboard" class="mr-3 -mt-1 text-primary">
+  <a routerLink="/dashboard" class="mr-3 text-primary">
     <mat-icon
       aria-hidden="false"
       aria-label="Example home icon"

--- a/src/app/modules/wallet/components/account-actions/account-actions.component.html
+++ b/src/app/modules/wallet/components/account-actions/account-actions.component.html
@@ -16,7 +16,7 @@
     <button
       mat-raised-button
       color="primary"
-      *ngIf="wallet.keymanagerKind === 'DERIVED' || wallet.keymanagerKind === 'DIRECT'"
+      *ngIf="!wallet.keymanagerKind || wallet.keymanagerKind === 'DIRECT'"
       class="large-btn">
       <span class="flex items-center">
         <span class="mr-2">New Account</span>

--- a/src/app/modules/wallet/components/account-actions/account-actions.component.html
+++ b/src/app/modules/wallet/components/account-actions/account-actions.component.html
@@ -3,7 +3,7 @@
     <button
       mat-raised-button
       color="accent"
-      *ngIf="wallet.keymanagerKind === Kinds.DIRECT"
+      *ngIf="wallet.keymanagerKind === 'DIRECT'"
       class="large-btn">
       <span class="flex items-center">
         <span class="mr-2">Import</span>
@@ -11,12 +11,12 @@
       </span>
     </button>
   </a>
-  <div class="mx-2" *ngIf="wallet.keymanagerKind === Kinds.DIRECT"></div>
+  <div class="mx-2" *ngIf="wallet.keymanagerKind === 'DIRECT'"></div>
   <a routerLink="/dashboard/wallet/accounts/create">
     <button
       mat-raised-button
       color="primary"
-      *ngIf="wallet.keymanagerKind === Kinds.DERIVED || wallet.keymanagerKind === Kinds.DIRECT"
+      *ngIf="wallet.keymanagerKind === 'DERIVED' || wallet.keymanagerKind === 'DIRECT'"
       class="large-btn">
       <span class="flex items-center">
         <span class="mr-2">New Account</span>

--- a/src/app/modules/wallet/components/account-actions/account-actions.component.html
+++ b/src/app/modules/wallet/components/account-actions/account-actions.component.html
@@ -16,7 +16,7 @@
     <button
       mat-raised-button
       color="primary"
-      *ngIf="!wallet.keymanagerKind || wallet.keymanagerKind === 'DIRECT'"
+      *ngIf="!wallet.keymanagerKind || wallet.keymanagerKind === 'DIRECT' || wallet.keymanagerKind === 'DERIVED'"
       class="large-btn">
       <span class="flex items-center">
         <span class="mr-2">New Account</span>

--- a/src/app/modules/wallet/components/account-actions/account-actions.component.spec.ts
+++ b/src/app/modules/wallet/components/account-actions/account-actions.component.spec.ts
@@ -3,7 +3,7 @@ import { MockService } from 'ng-mocks';
 import { of } from 'rxjs';
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
-import { KeymanagerKind, WalletResponse } from 'src/app/proto/validator/accounts/v2/web_api';
+import { WalletResponse } from 'src/app/proto/validator/accounts/v2/web_api';
 
 import { AccountActionsComponent } from './account-actions.component';
 
@@ -12,7 +12,7 @@ describe('AccountActionsComponent', () => {
   let fixture: ComponentFixture<AccountActionsComponent>;
   let service: WalletService = MockService(WalletService);
   service.walletConfig$ = of({
-    keymanagerKind: KeymanagerKind.DERIVED,
+    keymanagerKind: 'DERIVED',
   } as WalletResponse);
 
   beforeEach(async(() => {

--- a/src/app/modules/wallet/components/account-actions/account-actions.component.ts
+++ b/src/app/modules/wallet/components/account-actions/account-actions.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
-import { KeymanagerKind } from 'src/app/proto/validator/accounts/v2/web_api';
 
 @Component({
   selector: 'app-account-actions',
@@ -12,6 +11,5 @@ export class AccountActionsComponent {
   constructor(
     private walletService: WalletService,
   ) { }
-  Kinds = KeymanagerKind;
   walletConfig$ = this.walletService.walletConfig$;
 }

--- a/src/app/modules/wallet/components/accounts-table/accounts-table.component.html
+++ b/src/app/modules/wallet/components/accounts-table/accounts-table.component.html
@@ -42,7 +42,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header>ETH Balance</th>
       <td mat-cell *matCellDef="let row">
         <span [class.text-error]="row.lowBalance" [class.text-success]="!row.lowBalance">
-          {{row.balance}}
+          {{row.balance | balance}}
         </span>
       </td>
     </ng-container>
@@ -51,7 +51,7 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header> ETH Effective Balance</th>
       <td mat-cell *matCellDef="let row">
         <span [class.text-error]="row.lowBalance" [class.text-success]="!row.lowBalance">
-          {{row.effectiveBalance}}
+          {{row.effectiveBalance | balance}}
         </span>
       </td>
     </ng-container>
@@ -67,12 +67,12 @@
 
     <ng-container matColumnDef="activationEpoch">
       <th mat-header-cell *matHeaderCellDef mat-sort-header> Activation Epoch</th>
-      <td mat-cell *matCellDef="let row"> {{row.activationEpoch}} </td>
+      <td mat-cell *matCellDef="let row"> {{row.activationEpoch | epoch}} </td>
     </ng-container>
 
     <ng-container matColumnDef="exitEpoch">
       <th mat-header-cell *matHeaderCellDef mat-sort-header> Exit Epoch</th>
-      <td mat-cell *matCellDef="let row"> {{row.exitEpoch}} </td>
+      <td mat-cell *matCellDef="let row"> {{row.exitEpoch | epoch}} </td>
     </ng-container>
 
     <ng-container matColumnDef="options">

--- a/src/app/modules/wallet/components/accounts-table/accounts-table.component.ts
+++ b/src/app/modules/wallet/components/accounts-table/accounts-table.component.ts
@@ -17,11 +17,11 @@ export interface TableData {
   accountName: string;
   index: number;
   publicKey: string;
-  balance: number;
-  effectiveBalance: number;
+  balance: string;
+  effectiveBalance: string;
   status: string;
-  activationEpoch: number;
-  exitEpoch: number;
+  activationEpoch: string;
+  exitEpoch: string;
   lowBalance: boolean;
   options: string;
 }

--- a/src/app/modules/wallet/components/backup-selected-accounts/backup-selected-accounts.component.html
+++ b/src/app/modules/wallet/components/backup-selected-accounts/backup-selected-accounts.component.html
@@ -67,7 +67,7 @@
         <img src="/assets/images/backup.svg"/>
       </div>
       <button mat-stroked-button (click)="downloadBackup()">
-        Download Backup.zip
+        Download Backup File
       </button>
     </div>
   </ng-container>

--- a/src/app/modules/wallet/components/backup-selected-accounts/backup-selected-accounts.component.spec.ts
+++ b/src/app/modules/wallet/components/backup-selected-accounts/backup-selected-accounts.component.spec.ts
@@ -64,7 +64,7 @@ describe('BackupSelectedAccountsComponent', () => {
     fixture.detectChanges();
     expect(service.backupAccounts).toHaveBeenCalledWith({
       publicKeys: mockPublicKeys,
-      keystoresPassword: strongPassword,
+      backupPassword: strongPassword,
     } as BackupAccountsRequest);
   });
 
@@ -96,7 +96,7 @@ describe('BackupSelectedAccountsComponent', () => {
       fixture.detectChanges();
       expect(service.backupAccounts).toHaveBeenCalledWith({
         publicKeys: mockPublicKeys,
-        keystoresPassword: strongPassword,
+        backupPassword: strongPassword,
       } as BackupAccountsRequest);
     });
   });

--- a/src/app/modules/wallet/components/files-and-directories/files-and-directories.component.html
+++ b/src/app/modules/wallet/components/files-and-directories/files-and-directories.component.html
@@ -11,7 +11,7 @@
         {{wallet?.walletPath}}
       </div>
     </div>
-    <div *ngIf="wallet?.keymanagerKind === Kinds.DIRECT">
+    <div *ngIf="wallet?.keymanagerKind === 'DIRECT'">
       <div class="flex justify-between">
         <div class="text-white uppercase">Accounts Keystore File</div>
         <mat-icon aria-hidden="false" aria-label="Example home icon" class="text-muted mt-1 text-base cursor-pointer" matTooltip="hello">
@@ -22,7 +22,7 @@
         {{wallet?.walletPath}}/direct/all-accounts.keystore.json
       </div>
     </div>
-    <div *ngIf="wallet?.keymanagerKind === Kinds.DERIVED">
+    <div *ngIf="wallet?.keymanagerKind === 'DERIVED'">
       <div class="flex justify-between">
         <div class="text-white uppercase">Encrypted Seed File</div>
         <mat-icon aria-hidden="false" aria-label="Example home icon" class="text-muted mt-1 text-base cursor-pointer" matTooltip="hello">

--- a/src/app/modules/wallet/components/files-and-directories/files-and-directories.component.ts
+++ b/src/app/modules/wallet/components/files-and-directories/files-and-directories.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { KeymanagerKind, WalletResponse } from 'src/app/proto/validator/accounts/v2/web_api';
+import { WalletResponse } from 'src/app/proto/validator/accounts/v2/web_api';
 
 @Component({
   selector: 'app-files-and-directories',
@@ -9,5 +9,4 @@ import { KeymanagerKind, WalletResponse } from 'src/app/proto/validator/accounts
 export class FilesAndDirectoriesComponent {
   @Input() wallet: WalletResponse | null = null;
   constructor() { }
-  Kinds = KeymanagerKind;
 }

--- a/src/app/modules/wallet/components/wallet-config/wallet-config.component.html
+++ b/src/app/modules/wallet/components/wallet-config/wallet-config.component.html
@@ -6,7 +6,7 @@
     </div>
   </div>
   <div class="text-primary mb-4 text-base lowercase">
-    {{wallet?.walletPath}}/{{toString(wallet?.keymanagerKind)}}/keymanageropts.json
+    {{wallet?.walletPath}}/{{wallet?.keymanagerKind}}/keymanageropts.json
   </div>
   <div class="bg-black rounded p-4 text-success text-base">
     <div [innerHTML]="wallet?.keymanagerConfig | prettyjson"></div>

--- a/src/app/modules/wallet/components/wallet-config/wallet-config.component.ts
+++ b/src/app/modules/wallet/components/wallet-config/wallet-config.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { KeymanagerKind, KeymanagerKindToJSON, WalletResponse } from 'src/app/proto/validator/accounts/v2/web_api';
+import { WalletResponse } from 'src/app/proto/validator/accounts/v2/web_api';
 
 @Component({
   selector: 'app-wallet-config',
@@ -9,7 +9,4 @@ import { KeymanagerKind, KeymanagerKindToJSON, WalletResponse } from 'src/app/pr
 export class WalletConfigComponent {
   @Input() wallet: WalletResponse | null = null;
   constructor() {}
-  toString(keymanager: KeymanagerKind): string {
-    return KeymanagerKindToJSON(keymanager);
-  }
 }

--- a/src/app/modules/wallet/components/wallet-kind/wallet-kind.component.html
+++ b/src/app/modules/wallet/components/wallet-kind/wallet-kind.component.html
@@ -1,19 +1,19 @@
 <mat-card class="bg-primary">
   <div 
-    *ngIf="parseKeymanagerKind() as key"
+    *ngIf="kind"
     class="wallet-kind-card relative flex items-center justify-between px-4 pt-4">
     <div class="pr-4 w-3/4">
       <p class="m-0 uppercase text-muted text-sm leading-snug">
           YOUR WALLET KIND
       </p>
       <div class="text-2xl mb-4 text-white leading-snug">
-        {{info[key].name}}
+        {{info[kind].name}}
       </div>
       <p class="m-0 text-muted text-base leading-snug">
-        {{info[key].description}}
+        {{info[kind].description}}
       </p>
       <div class="mt-6 mb-4">
-        <a [href]="info[key].docsLink" target="_blank">
+        <a [href]="info[kind].docsLink" target="_blank">
           <button mat-raised-button color="accent">
             Read More
           </button>

--- a/src/app/modules/wallet/components/wallet-kind/wallet-kind.component.ts
+++ b/src/app/modules/wallet/components/wallet-kind/wallet-kind.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { KeymanagerKind, KeymanagerKindToJSON } from 'src/app/proto/validator/accounts/v2/web_api';
 
 interface KeymanagerInfo {
   [key: string]: {
@@ -15,7 +14,7 @@ interface KeymanagerInfo {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WalletKindComponent {
-  @Input() kind: KeymanagerKind = KeymanagerKind.UNRECOGNIZED;
+  @Input() kind = 'UNKNOWN';
   constructor() { }
   info: KeymanagerInfo = {
     DIRECT: {
@@ -39,8 +38,4 @@ export class WalletKindComponent {
       docsLink: 'https://docs.prylabs.network/docs/wallet/remote',
     }
   };
-
-  parseKeymanagerKind(): string {
-    return KeymanagerKindToJSON(this.kind);
-  }
 }

--- a/src/app/modules/wallet/pages/accounts/accounts.component.spec.ts
+++ b/src/app/modules/wallet/pages/accounts/accounts.component.spec.ts
@@ -17,14 +17,16 @@ describe('AccountsComponent', () => {
   let fixture: ComponentFixture<AccountsComponent>;
   let service: WalletService = MockService(WalletService);
   const valService: ValidatorService = MockService(ValidatorService);
-  service.accounts$ = of({
-    accounts: [{
-      validatingPublicKey: '',
-      accountName: 'Fritz',
-      depositTxData: '',
-      derivationPath: 'somepath'
-    }] as Account[],
-  } as ListAccountsResponse);
+  service.accounts = () => {
+      return of({
+      accounts: [{
+        validatingPublicKey: '',
+        accountName: 'Fritz',
+        depositTxData: '',
+        derivationPath: 'somepath'
+      }] as Account[],
+    } as ListAccountsResponse);
+  };
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/app/modules/wallet/pages/create-account/create-account.component.html
+++ b/src/app/modules/wallet/pages/create-account/create-account.component.html
@@ -10,27 +10,29 @@
               <button color="accent" mat-raised-button>Back to Accounts</button>
             </a>
             <span class="mx-3"></span>
-            <button color="primary" mat-raised-button>Continue</button>
+            <button color="primary" mat-raised-button (click)="createAccounts()">Continue</button>
           </div>
         </mat-step>
         <mat-step label="Deposit Data">
-          <div class="text-white text-xl mt-4">
-            Your Deposit Data
-          </div>
-          <div class="my-4 text-hint text-lg leading-snug">
-            Copy or download your deposit_data.json file which you can use to deposit all your newly created accounts into
-            the official eth2 launchpad
-          </div>
-          <div class="bg-black rounded p-4 text-success text-base">
-            <div [innerHTML]="depositData | prettyjson" class="overflow-auto"></div>
-          </div>
-          <div class="mt-6">
-            <a [href]="generateDownloadJSONUri(depositData)" [download]="depositDataFileName">
-              <button color="accent" mat-raised-button>Download JSON File</button>
-            </a>
-            <span class="mx-3"></span>
-            <button color="primary" mat-raised-button (click)="copy(depositData)">Copy to Clipboard</button>
-          </div>
+          <ng-template *ngIf="depositData">
+            <div class="text-white text-xl mt-4">
+              Your Deposit Data
+            </div>
+            <div class="my-4 text-hint text-lg leading-snug">
+              Copy or download your deposit_data.json file which you can use to deposit all your newly created accounts into
+              the official eth2 launchpad
+            </div>
+            <div class="bg-black rounded p-4 text-success text-base">
+              <div [innerHTML]="depositData | prettyjson" class="overflow-auto"></div>
+            </div>
+            <div class="mt-6">
+              <a [href]="generateDownloadJSONUri(depositData)" [download]="depositDataFileName">
+                <button color="accent" mat-raised-button>Download JSON File</button>
+              </a>
+              <span class="mx-3"></span>
+              <button color="primary" mat-raised-button (click)="copy(depositData)">Copy to Clipboard</button>
+            </div>
+          </ng-template>
         </mat-step>
       </mat-horizontal-stepper>
     </div>

--- a/src/app/modules/wallet/pages/create-account/create-account.component.html
+++ b/src/app/modules/wallet/pages/create-account/create-account.component.html
@@ -14,25 +14,23 @@
           </div>
         </mat-step>
         <mat-step label="Deposit Data">
-          <ng-template *ngIf="depositData">
-            <div class="text-white text-xl mt-4">
-              Your Deposit Data
-            </div>
-            <div class="my-4 text-hint text-lg leading-snug">
-              Copy or download your deposit_data.json file which you can use to deposit all your newly created accounts into
-              the official eth2 launchpad
-            </div>
-            <div class="bg-black rounded p-4 text-success text-base">
-              <div [innerHTML]="depositData | prettyjson" class="overflow-auto"></div>
-            </div>
-            <div class="mt-6">
-              <a [href]="generateDownloadJSONUri(depositData)" [download]="depositDataFileName">
-                <button color="accent" mat-raised-button>Download JSON File</button>
-              </a>
-              <span class="mx-3"></span>
-              <button color="primary" mat-raised-button (click)="copy(depositData)">Copy to Clipboard</button>
-            </div>
-          </ng-template>
+          <div class="text-white text-xl mt-4">
+            Your Deposit Data
+          </div>
+          <div class="my-4 text-hint text-lg leading-snug">
+            Copy or download your deposit_data.json file which you can use to deposit all your newly created accounts into
+            the official eth2 launchpad
+          </div>
+          <div class="bg-black rounded p-4 text-success text-base">
+            <div [innerHTML]="depositData | prettyjson" class="overflow-auto"></div>
+          </div>
+          <div class="mt-6">
+            <a [href]="generateDownloadJSONUri(depositData)" [download]="depositDataFileName">
+              <button color="accent" mat-raised-button>Download JSON File</button>
+            </a>
+            <span class="mx-3"></span>
+            <button color="primary" mat-raised-button (click)="copy(depositData)">Copy to Clipboard</button>
+          </div>
         </mat-step>
       </mat-horizontal-stepper>
     </div>

--- a/src/app/modules/wallet/pages/create-account/create-account.component.spec.ts
+++ b/src/app/modules/wallet/pages/create-account/create-account.component.spec.ts
@@ -1,5 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MockService } from 'ng-mocks';
+import { WalletService } from 'src/app/modules/core/services/wallet.service';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { CreateAccountComponent } from './create-account.component';
@@ -7,6 +9,7 @@ import { CreateAccountComponent } from './create-account.component';
 describe('CreateAccountComponent', () => {
   let component: CreateAccountComponent;
   let fixture: ComponentFixture<CreateAccountComponent>;
+  let service: WalletService = MockService(WalletService);
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -15,9 +18,13 @@ describe('CreateAccountComponent', () => {
         SharedModule,
         FormsModule,
         ReactiveFormsModule,
+      ],
+      providers: [
+        { provide: WalletService, useValue: service },
       ]
     })
     .compileComponents();
+    service = TestBed.inject(WalletService);
   }));
 
   beforeEach(() => {

--- a/src/app/modules/wallet/pages/create-account/create-account.component.ts
+++ b/src/app/modules/wallet/pages/create-account/create-account.component.ts
@@ -1,24 +1,31 @@
 import { Clipboard } from '@angular/cdk/clipboard';
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatStepper } from '@angular/material/stepper';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+import { throwError } from 'rxjs';
+import { catchError, take, tap } from 'rxjs/operators';
 
 import { MAX_ACCOUNTS_CREATION } from 'src/app/modules/core/constants';
 import { mockDepositDataJSON } from 'src/app/modules/core/mocks';
-import { DepositDataResponse_DepositData } from 'src/app/proto/validator/accounts/v2/web_api';
+import { WalletService } from 'src/app/modules/core/services/wallet.service';
+import { CreateAccountsRequest, DepositDataResponse_DepositData } from 'src/app/proto/validator/accounts/v2/web_api';
 
 @Component({
   selector: 'app-create-account',
   templateUrl: './create-account.component.html',
 })
 export class CreateAccountComponent {
+  @ViewChild('stepper') stepper?: MatStepper;
   constructor(
     private fb: FormBuilder,
     private clipboard: Clipboard,
     private snackBar: MatSnackBar,
     private sanitizer: DomSanitizer,
+    private walletService: WalletService,
   ) { }
+  loading = false;
   maxAccounts = MAX_ACCOUNTS_CREATION;
   accountsFormGroup = this.fb.group({
     numAccounts: new FormControl('', [
@@ -40,5 +47,30 @@ export class CreateAccountComponent {
     this.snackBar.open('Copied JSON string to clipboard', 'Close', {
       duration: 4000,
     });
+  }
+
+  createAccounts(): void {
+    this.accountsFormGroup.markAllAsTouched();
+    if (this.accountsFormGroup.invalid) {
+      return;
+    }
+    const req: CreateAccountsRequest = {
+      numAccounts: this.accountsFormGroup.controls.numAccounts.value,
+    };
+    this.loading = true;
+    this.walletService.createAccounts(req).pipe(
+      take(1),
+      tap(() => {
+        this.snackBar.open(`Successfully created ${req.numAccounts} accounts`, 'Close', {
+          duration: 4000,
+        });
+        this.loading = false;
+        this.stepper?.next();
+      }),
+      catchError(err => {
+        this.loading = false;
+        return throwError(err);
+      })
+    ).subscribe();
   }
 }

--- a/src/app/modules/wallet/pages/create-account/create-account.component.ts
+++ b/src/app/modules/wallet/pages/create-account/create-account.component.ts
@@ -10,7 +10,7 @@ import { catchError, take, tap } from 'rxjs/operators';
 import { MAX_ACCOUNTS_CREATION } from 'src/app/modules/core/constants';
 import { mockDepositDataJSON } from 'src/app/modules/core/mocks';
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
-import { CreateAccountsRequest, DepositDataResponse_DepositData } from 'src/app/proto/validator/accounts/v2/web_api';
+import { CreateAccountsRequest, DepositDataResponse, DepositDataResponse_DepositData } from 'src/app/proto/validator/accounts/v2/web_api';
 
 @Component({
   selector: 'app-create-account',
@@ -34,7 +34,7 @@ export class CreateAccountComponent {
       Validators.max(MAX_ACCOUNTS_CREATION),
     ]),
   });
-  depositData = mockDepositDataJSON;
+  depositData: DepositDataResponse_DepositData[] = [];
   depositDataFileName = 'deposit_data-23920932.json';
 
   generateDownloadJSONUri(data: DepositDataResponse_DepositData[]): SafeUrl {
@@ -60,11 +60,12 @@ export class CreateAccountComponent {
     this.loading = true;
     this.walletService.createAccounts(req).pipe(
       take(1),
-      tap(() => {
+      tap((res: DepositDataResponse) => {
         this.snackBar.open(`Successfully created ${req.numAccounts} accounts`, 'Close', {
           duration: 4000,
         });
         this.loading = false;
+        this.depositData = res.depositDataList.map(d => d.data);
         this.stepper?.next();
       }),
       catchError(err => {

--- a/src/app/modules/wallet/pages/import/import.component.ts
+++ b/src/app/modules/wallet/pages/import/import.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { AbstractControl, FormBuilder, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 import { throwError } from 'rxjs';
 import { catchError, take, tap } from 'rxjs/operators';
 import { MAX_ALLOWED_KEYSTORES } from 'src/app/modules/core/constants';
@@ -16,6 +17,7 @@ export class ImportComponent {
     private fb: FormBuilder,
     private walletService: WalletService,
     private snackBar: MatSnackBar,
+    private router: Router,
   ) { }
   loading = false;
   importFormGroup = this.fb.group({
@@ -45,6 +47,7 @@ export class ImportComponent {
           duration: 4000,
         });
         this.loading = false;
+        this.router.navigate(['/dashboard/wallet/accounts']);
       }),
       catchError(err => {
         this.loading = false;

--- a/src/app/modules/wallet/pages/import/import.component.ts
+++ b/src/app/modules/wallet/pages/import/import.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { AbstractControl, FormBuilder, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
 import { throwError } from 'rxjs';
 import { catchError, take, tap } from 'rxjs/operators';
 import { MAX_ALLOWED_KEYSTORES } from 'src/app/modules/core/constants';
@@ -17,7 +16,6 @@ export class ImportComponent {
     private fb: FormBuilder,
     private walletService: WalletService,
     private snackBar: MatSnackBar,
-    private router: Router,
   ) { }
   loading = false;
   importFormGroup = this.fb.group({
@@ -47,7 +45,6 @@ export class ImportComponent {
           duration: 4000,
         });
         this.loading = false;
-        this.router.navigate(['/dashboard/wallet/accounts']);
       }),
       catchError(err => {
         this.loading = false;

--- a/src/app/modules/wallet/pages/wallet-details/wallet-details.component.html
+++ b/src/app/modules/wallet/pages/wallet-details/wallet-details.component.html
@@ -8,9 +8,9 @@
       Information about your current wallet and its configuration options
     </p>
   </div>
-  <div class="flex items-center gap-x-6" *ngIf="!loading && wallet">
+  <div class="flex items-center gap-x-6" *ngIf="!loading && wallet && keymanagerKind">
     <div class="w-1/2">
-      <app-wallet-kind [kind]="wallet?.keymanagerKind"></app-wallet-kind>
+      <app-wallet-kind [kind]="keymanagerKind"></app-wallet-kind>
     </div>
     <div class="w-1/2 px-0 md:px-6">
       <mat-tab-group animationDuration="0ms" backgroundColor="primary">

--- a/src/app/modules/wallet/pages/wallet-details/wallet-details.component.ts
+++ b/src/app/modules/wallet/pages/wallet-details/wallet-details.component.ts
@@ -38,7 +38,6 @@ export class WalletDetailsComponent implements OnInit, OnDestroy {
         } else {
           this.keymanagerKind = this.wallet.keymanagerKind;
         }
-        console.log(res);
       }),
       catchError((err) => {
         this.loading = false;

--- a/src/app/modules/wallet/pages/wallet-details/wallet-details.component.ts
+++ b/src/app/modules/wallet/pages/wallet-details/wallet-details.component.ts
@@ -32,6 +32,7 @@ export class WalletDetailsComponent implements OnInit, OnDestroy {
       tap((res: WalletResponse) => {
         this.loading = false;
         this.wallet = res;
+        console.log(res);
       }),
       catchError((err) => {
         this.loading = false;

--- a/src/app/modules/wallet/pages/wallet-details/wallet-details.component.ts
+++ b/src/app/modules/wallet/pages/wallet-details/wallet-details.component.ts
@@ -15,6 +15,7 @@ export class WalletDetailsComponent implements OnInit, OnDestroy {
   private destroyed$ = new Subject<void>();
   loading = false;
   wallet: WalletResponse | null = null;
+  keymanagerKind = 'UNKNOWN';
 
   ngOnInit(): void {
     this.fetchData();
@@ -32,6 +33,11 @@ export class WalletDetailsComponent implements OnInit, OnDestroy {
       tap((res: WalletResponse) => {
         this.loading = false;
         this.wallet = res;
+        if (!this.wallet.keymanagerKind) {
+          this.keymanagerKind = 'DERIVED';
+        } else {
+          this.keymanagerKind = this.wallet.keymanagerKind;
+        }
         console.log(res);
       }),
       catchError((err) => {

--- a/src/app/modules/wallet/pipes/balance.pipe.ts
+++ b/src/app/modules/wallet/pipes/balance.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/*
+ * Formats a validator balance, showing n/a if 0.
+*/
+@Pipe({name: 'balance'})
+export class BalancePipe implements PipeTransform {
+  transform(n: string): string {
+    if (n === '0') {
+      return 'n/a';
+    }
+    return n;
+  }
+}

--- a/src/app/modules/wallet/pipes/format-epoch.pipe.ts
+++ b/src/app/modules/wallet/pipes/format-epoch.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { FAR_FUTURE_EPOCH } from 'src/app/modules/core/constants';
+
+/*
+ * Formats an epoch, such as 0 to 'genesis' and FAR_FUTURE_EPOCH to 'n/a'
+*/
+@Pipe({name: 'epoch'})
+export class EpochPipe implements PipeTransform {
+  transform(n: number): string {
+    if (n === 0) {
+      return 'genesis';
+    } else if (n.toString() === FAR_FUTURE_EPOCH) {
+      return 'n/a';
+    }
+    return n.toString();
+  }
+}

--- a/src/app/modules/wallet/wallet.module.ts
+++ b/src/app/modules/wallet/wallet.module.ts
@@ -19,6 +19,8 @@ import { ImportComponent } from './pages/import/import.component';
 import { NgxFileDropModule } from 'ngx-file-drop';
 import { BackupSelectedAccountsComponent } from './components/backup-selected-accounts/backup-selected-accounts.component';
 import { DeleteSelectedAccountsComponent } from './components/delete-selected-accounts/delete-selected-accounts.component';
+import { EpochPipe } from './pipes/format-epoch.pipe';
+import { BalancePipe } from './pipes/balance.pipe';
 
 @NgModule({
   declarations: [
@@ -36,6 +38,8 @@ import { DeleteSelectedAccountsComponent } from './components/delete-selected-ac
     ImportComponent,
     BackupSelectedAccountsComponent,
     DeleteSelectedAccountsComponent,
+    EpochPipe,
+    BalancePipe,
   ],
   imports: [
     CommonModule,

--- a/src/app/proto/eth/v1alpha1/validator.ts
+++ b/src/app/proto/eth/v1alpha1/validator.ts
@@ -338,27 +338,27 @@ export interface Validator {
    *  be zero if the validator was present in the Ethereum 2.0 genesis. This
    *  field is FAR_FUTURE_EPOCH if the validator has not been activated.
    */
-  activationEligibilityEpoch: number;
+  activationEligibilityEpoch: string;
   /**
    *  Epoch when the validator was activated. This field may be zero if the
    *  validator was present in the Ethereum 2.0 genesis. This field is
    *  FAR_FUTURE_EPOCH if the validator has not been activated.
    */
-  activationEpoch: number;
+  activationEpoch: string;
   /**
    *  Epoch when the validator was exited. This field is FAR_FUTURE_EPOCH if
    *  the validator has not exited.
    *  FAR_FUTURE_EPOCH is a constant defined by the official Ethereum 2.0 specification:
    *  https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/core/0_beacon-chain.md#constants
    */
-  exitEpoch: number;
+  exitEpoch: string;
   /**
    *  Epoch when the validator is eligible to withdraw their funds. This field
    *  is FAR_FUTURE_EPOCH if the validator has not exited.
    *  FAR_FUTURE_EPOCH is a constant defined by the official Ethereum 2.0 specification:
    *  https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/core/0_beacon-chain.md#constants
    */
-  withdrawableEpoch: number;
+  withdrawableEpoch: string;
 }
 
 /**

--- a/src/app/proto/validator/accounts/v2/web_api.ts
+++ b/src/app/proto/validator/accounts/v2/web_api.ts
@@ -70,10 +70,35 @@ export interface ListAccountsRequest {
    *  Whether or not to return the raw RLP deposit tx data.
    */
   getDepositTxData: boolean;
+  /**
+   *  The maximum number of data to return in the response.
+   *  This field is optional.
+   */
+  pageSize: number;
+  /**
+   *  A pagination token returned from a previous call
+   *  that indicates where this listing should continue from.
+   *  This field is optional.
+   */
+  pageToken: string;
+  /**
+   *  Whether or not to return all acconts.
+   */
+  all: boolean;
 }
 
 export interface ListAccountsResponse {
   accounts: Account[];
+  /**
+   *  A pagination token returned from a previous call
+   *  that indicates from where listing should continue.
+   *  This field is optional.
+   */
+  nextPageToken: string;
+  /**
+   *  Total count matching the request filter.
+   */
+  totalSize: number;
 }
 
 export interface Account {

--- a/src/app/proto/validator/accounts/v2/web_api.ts
+++ b/src/app/proto/validator/accounts/v2/web_api.ts
@@ -9,7 +9,7 @@ export interface CreateWalletRequest {
    *  Path on disk where the wallet will be stored.
    */
   walletPath: string;
-  keymanager: KeymanagerKind;
+  keymanager: string;
   /**
    *  Password for the wallet.
    */
@@ -61,12 +61,8 @@ export interface GenerateMnemonicResponse {
 
 export interface WalletResponse {
   walletPath: string;
-  keymanagerKind: KeymanagerKind;
+  keymanagerKind: string;
   keymanagerConfig: { [key: string]: string };
-}
-
-export interface CreateAccountResponse {
-  account: Account | undefined;
 }
 
 export interface ListAccountsRequest {
@@ -172,7 +168,7 @@ export interface ImportKeystoresResponse {
   importedPublicKeys: string[];
 }
 
-export interface CreateAccountRequest {
+export interface CreateAccountsRequest {
   /**
    *  Number of accounts to create.
    */
@@ -180,17 +176,21 @@ export interface CreateAccountRequest {
 }
 
 export interface DepositDataResponse {
-  depositDataList: DepositDataResponse_DepositData[];
+  depositDataList: DepositDataResponse_DepositData_Wrapper[];
+}
+
+export interface DepositDataResponse_DepositData_Wrapper {
+  data: DepositDataResponse_DepositData;
 }
 
 export interface DepositDataResponse_DepositData {
   pubkey: string;
-  withdrawalCredentials: string;
+  withdrawal_credentials: string;
   amount: number;
   signature: string;
-  depositMessageRoot: string;
-  depositDataRoot: string;
-  forkVersion: string;
+  deposit_message_root: string;
+  deposit_data_root: string;
+  fork_version: string;
 }
 
 export interface BackupAccountsRequest {
@@ -201,7 +201,7 @@ export interface BackupAccountsRequest {
   /**
    *  Keystores password to encrypt the backed-up accounts.
    */
-  keystoresPassword: string;
+  backupPassword: string;
 }
 
 export interface BackupAccountsResponse {
@@ -223,44 +223,4 @@ export interface DeleteAccountsResponse {
    *  Public keys that were deleted.
    */
   deletedKeys: string[];
-}
-
-/**  Type of key manager for the wallet, either direct, derived, or remote.
- */
-export enum KeymanagerKind {
-  DERIVED = 0,
-  DIRECT = 1,
-  REMOTE = 2,
-  UNRECOGNIZED = -1,
-}
-
-export function KeymanagerKindFromJSON(object: any): KeymanagerKind {
-  switch (object) {
-    case 0:
-    case 'DERIVED':
-      return KeymanagerKind.DERIVED;
-    case 1:
-    case 'DIRECT':
-      return KeymanagerKind.DIRECT;
-    case 2:
-    case 'REMOTE':
-      return KeymanagerKind.REMOTE;
-    case -1:
-    case 'UNRECOGNIZED':
-    default:
-      return KeymanagerKind.UNRECOGNIZED;
-  }
-}
-
-export function KeymanagerKindToJSON(object: KeymanagerKind): string {
-  switch (object) {
-    case KeymanagerKind.DERIVED:
-      return 'DERIVED';
-    case KeymanagerKind.DIRECT:
-      return 'DIRECT';
-    case KeymanagerKind.REMOTE:
-      return 'REMOTE';
-    default:
-      return 'UNKNOWN';
-  }
 }


### PR DESCRIPTION
This PR includes a variety of fixes towards our beta launch, including:
- [x] Fixing the issues of getting default or no data back for certain backend calls, such as the list validators or list balances
- [x] Ability to create and download a backup.zip file in the backup keystores component using the jszip node package
- [x] Fixes certain types there were marked as numbers to be marked as strings, such as epochs which are too big for js to represent normally
- [x] Fixes cases where we could divide by 0 when empty responses were returned from the backend
- [x] Removed share replay from various service values and instead used `share()`. Share replay would cause us to see the same accounts even if new ones were imported or old ones deleted
- [x] Our base64 to hex utils were broken, not working as intended at all. This PR adds the proper implementation and conformance tests to ensure the encoding and decoding is correct based on known values
- [x] Includes pipes to format epochs and indices, such as showing n/a if FAR_FUTURE_EPOCH is the value from the backend
- [x] Implement the actual `CreateAccount` logic, allowing us to perform that action successfully
