### PR TITLE
Table styles and key truncation on dashboard for smaller screens

### DIFF
--- a/src/app/modules/dashboard/components/activation-queue/activation-queue.component.html
+++ b/src/app/modules/dashboard/components/activation-queue/activation-queue.component.html
@@ -30,8 +30,8 @@
       {{userKeys.length}} of your keys pending activation
     </div>
     <div *ngFor="let key of (userKeys | slice:0:4)">
-      <div class="text-white text-base my-2">
-        {{((key | base64tohex) | slice:0:30)+'...'}}
+      <div class="text-white text-base my-2 truncate">
+        {{(key | base64tohex)}}
       </div>
       <div 
         class="flex" 
@@ -54,8 +54,8 @@
       {{userKeys.length}} of your keys pending exit
     </div>
     <div *ngFor="let key of (userKeys | slice:0:4)">
-      <div class="text-white text-base my-2">
-        {{((key | base64tohex) | slice:0:30)+'...'}}
+      <div class="text-white text-base my-2 truncate">
+        {{(key | base64tohex)}}
       </div>
       <div 
         class="flex" 

--- a/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.html
+++ b/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.html
@@ -11,7 +11,7 @@
     </div>
   </div>
   <div class="mt-4 mb-2">
-    <div class="text-muted text-lg">
+    <div class="text-muted text-lg truncate">
       {{endpoint$ | async}}
     </div>
     <div

--- a/src/app/modules/dashboard/components/validator-performance-list/validator-performance-list.component.html
+++ b/src/app/modules/dashboard/components/validator-performance-list/validator-performance-list.component.html
@@ -11,8 +11,8 @@
     <tr style="display:none!important">
       <ng-container matColumnDef="publicKey">
         <th mat-header-cell *matHeaderCellDef>Public key</th>
-        <td mat-cell *matCellDef="let element">
-          {{element.publicKey | base64tohex | slice:0:20}}...
+        <td mat-cell *matCellDef="let element" class="truncate">
+          {{element.publicKey | base64tohex}}
         </td>
       </ng-container>
 

--- a/src/app/modules/wallet/components/accounts-table/accounts-table.component.html
+++ b/src/app/modules/wallet/components/accounts-table/accounts-table.component.html
@@ -28,8 +28,8 @@
         matTooltipPosition="left"
         matTooltip="Copy to Clipboard" 
         (click)="copyKeyToClipboard(row.publicKey)"
-        class="cursor-pointer"> 
-        {{row.publicKey | base64tohex | slice:0:12}}... 
+        class="cursor-pointer truncate"> 
+        {{row.publicKey | base64tohex }}
       </td>
     </ng-container>
 

--- a/src/styles/layouts/_index.scss
+++ b/src/styles/layouts/_index.scss
@@ -1,3 +1,4 @@
 @import "layout";
 @import "sidenav";
 @import "footer";
+@import "table";

--- a/src/styles/layouts/_table.scss
+++ b/src/styles/layouts/_table.scss
@@ -1,0 +1,22 @@
+table.mat-table {
+  mat-checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  th.mat-header-cell:first-of-type, td.mat-cell:first-of-type, td.mat-footer-cell:first-of-type {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+
+  th .mat-header-cell, td.mat-cell, td.mat-footer-cel {
+    max-width: 100px;
+    padding-left: 2px;
+    padding-right: 2px;
+
+    @media screen and (max-width: 1000px) {
+      max-width: 70px;
+    }
+  }
+}

--- a/src/styles/layouts/_table.scss
+++ b/src/styles/layouts/_table.scss
@@ -1,3 +1,7 @@
+.table-container {
+  overflow-x: auto;
+}
+
 table.mat-table {
   mat-checkbox {
     display: flex;


### PR DESCRIPTION
Problem: Tables (validator performance list and accounts list) and the keys on the dashboard are not shown properly on a smaller screen.

Sollution: Fixed some styles on the tables and truncated the keys. Working for minimum width of 768px.