### PR TITLE
Use /api PathPrefix for API Requests

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,5 +2,5 @@ import { IEnvironment } from './token';
 
 export const environment: IEnvironment = {
   production: true,
-  validatorEndpoint: '/v2/validator',
+  validatorEndpoint: '/api/v2/validator',
 };


### PR DESCRIPTION
To allow same origin requests in prod, we now serve our gRPC API for the validator at /api, so requests are done as `/api/v2/validator/signup`