### PR TITLE
Added escape character before backslashes in Windows path string [Fixes #89]

### DIFF
--- a/src/app/modules/onboarding/components/wallet-directory-form/wallet-directory-form.component.ts
+++ b/src/app/modules/onboarding/components/wallet-directory-form/wallet-directory-form.component.ts
@@ -9,6 +9,6 @@ export class WalletDirectoryFormComponent {
   @Input() formGroup: FormGroup | null = null;
   linux = '$HOME/.eth2validators/prysm-wallet-v2';
   macos = '$HOME/Library/Eth2Validators/prysm-wallet-v2';
-  windows = `%LOCALAPPDATA%\\Eth2Validators\\prysm-wallet-v2`;
+  windows = '%LOCALAPPDATA%\\Eth2Validators\\prysm-wallet-v2';
   constructor() { }
 }

--- a/src/app/modules/onboarding/components/wallet-directory-form/wallet-directory-form.component.ts
+++ b/src/app/modules/onboarding/components/wallet-directory-form/wallet-directory-form.component.ts
@@ -9,6 +9,6 @@ export class WalletDirectoryFormComponent {
   @Input() formGroup: FormGroup | null = null;
   linux = '$HOME/.eth2validators/prysm-wallet-v2';
   macos = '$HOME/Library/Eth2Validators/prysm-wallet-v2';
-  windows = `%LOCALAPPDATA%\Eth2Validators\prysm-wallet-v2`;
+  windows = `%LOCALAPPDATA%\\Eth2Validators\\prysm-wallet-v2`;
   constructor() { }
 }


### PR DESCRIPTION
### wallet-directory-form.component.ts
Simply changed single backslashes in window default wallet path string to `\\` to escape itself.

![image](https://user-images.githubusercontent.com/54227730/96801276-13afcd80-13bc-11eb-867c-ff8518543297.png)
