### PR TITLE
Fix log percentages in prysm process logs

### DIFF
--- a/src/app/modules/system-process/pages/logs/logs.component.ts
+++ b/src/app/modules/system-process/pages/logs/logs.component.ts
@@ -61,6 +61,7 @@ export class LogsComponent implements OnInit, OnDestroy {
     if (!val || !log) {
       return;
     }
+    log = log.toUpperCase();
     if (log.indexOf('INFO') !== -1) {
       this.totalInfo++;
       this.totalLogs++;


### PR DESCRIPTION
The logs that prysm client are in lowercase for the log status
codes (ERROR/INFO/WARN) for some clients. Normalizing it
before calculating the percentage would fix the NaN% bug

