### PR TITLE
Import Keystore: Add validation check

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { ENVIRONMENT } from 'src/environments/token';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -11,6 +12,9 @@ describe('AppComponent', () => {
       declarations: [
         AppComponent
       ],
+      providers: [
+        { provide: ENVIRONMENT, useValue: jasmine.createSpyObj('EnvironmenterService', ['env']) },
+      ]
     }).compileComponents();
   }));
 

--- a/src/app/modules/core/services/logs.service.spec.ts
+++ b/src/app/modules/core/services/logs.service.spec.ts
@@ -1,5 +1,6 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { EnvironmenterService } from './environmenter.service';
+import { ENVIRONMENT } from 'src/environments/token';
 
 import { LogsService } from './logs.service';
 
@@ -9,8 +10,11 @@ describe('LogsService', () => {
   beforeEach(() => {
     const envSpy = jasmine.createSpyObj('EnvironmenterService', ['env']);
     TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
       providers: [
-        { provide: EnvironmenterService, useValue: envSpy },
+        { provide: ENVIRONMENT, useValue: jasmine.createSpyObj('EnvironmenterService', ['env']) },
       ]
     });
     service = TestBed.inject(LogsService);

--- a/src/app/modules/core/services/validator.service.spec.ts
+++ b/src/app/modules/core/services/validator.service.spec.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { ValidatorBalances, ValidatorBalances_Balance } from 'src/app/proto/eth/v1alpha1/beacon_chain';
 import { hexToBase64 } from '../utils/hex-util';
 import { Account, ListAccountsResponse } from 'src/app/proto/validator/accounts/v2/web_api';
+import { ENVIRONMENT } from 'src/environments/token';
 
 describe('ValidatorService', () => {
   let service: ValidatorService;
@@ -23,6 +24,7 @@ describe('ValidatorService', () => {
         HttpClientTestingModule,
       ],
       providers: [
+        { provide: ENVIRONMENT, useValue: jasmine.createSpyObj('EnvironmenterService', ['env']) },
         { provide: BeaconNodeService, useValue: beaconNodeService },
         { provide: WalletService, useValue: walletService },
       ]

--- a/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.html
+++ b/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.html
@@ -31,23 +31,29 @@
             <button mat-stroked-button (click)="openFileSelector()" [disabled]="uploading">Browse Files</button>
           </ng-template>
       </ngx-file-drop>
-      <div class="mt-4 -mb-1">
-        <mat-error *ngIf="formGroup && formGroup.touched && formGroup.controls.keystoresImported.hasError('noKeystoresUploaded')">
-          Please upload at least 1 valid keystore file
-        </mat-error>
-        <mat-error *ngIf="formGroup && formGroup.touched && formGroup.controls.keystoresImported.hasError('tooManyKeystores')">
-          Max 50 keystore files allowed. If you have more than that, we recommend an HD wallet instead
-        </mat-error>
-      </div>
     </div>
     <div class="w-full md:w-1/2">
       <div *ngIf="filesPreview" class="text-white text-xl px-0 md:px-6 py-6 md:py-2">
-        <span class="font-semibold text-secondary">{{totalFiles}}</span> Files Selected
+        <span class="font-semibold text-secondary">{{filesPreview.length}}</span> Files Selected
         <div *ngFor="let file of filesPreview">
-          <div class="mt-3 text-muted text-base">{{file.relativePath}}</div>
+          <div class="mt-3 text-muted text-base">{{file}}</div>
         </div>
         <span *ngIf="filesPreview.length > MAX_FILES_BEFORE_PREVIEW">...</span>
       </div>
     </div>
+  </div>
+  <div class="my-6 flex flex-wrap">
+    <mat-error *ngIf="formGroup && formGroup.touched && formGroup.controls.keystoresImported.hasError('noKeystoresUploaded')">
+      Please upload at least 1 valid keystore file
+    </mat-error>
+    <mat-error *ngIf="formGroup && formGroup.touched && formGroup.controls.keystoresImported.hasError('tooManyKeystores')">
+      Max 50 keystore files allowed. If you have more than that, we recommend an HD wallet instead
+    </mat-error>
+    <mat-error *ngIf="invalidFiles.length">
+      Not adding these files:
+      <ul class="ml-8 list-inside list-disc">
+        <li *ngFor="let file of invalidFiles">{{file}}</li>
+      </ul>
+    </mat-error>
   </div>
 </div>

--- a/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
+++ b/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
@@ -67,7 +67,7 @@ export class ImportAccountsFormComponent {
       this.invalidFiles.push('Invalid Format: ' + fileName);
       return;
     }
-    
+
     const imported = this.formGroup?.get('keystoresImported')?.value as string[];
     const jsonString = JSON.stringify(jsonFile);
     if (imported.includes(jsonString)) {
@@ -84,9 +84,9 @@ export class ImportAccountsFormComponent {
     if (!Array.isArray(jsonFile)) {
       return false;
     }
-    
+
     // Lazy way checking if the attributes exists.
-    return (jsonFile as Array<Object>).every(item => 
+    return (jsonFile as Array<object>).every(item =>
         'pubkey' in item
         && 'withdrawal_credentials' in item
         && 'amount' in item

--- a/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
+++ b/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
@@ -16,16 +16,9 @@ export class ImportAccountsFormComponent {
 
   // Properties.
   MAX_FILES_BEFORE_PREVIEW = 3;
-  filesPreview: NgxFileDropEntry[] = [];
-  files: NgxFileDropEntry[] = [];
-  totalFiles = 0;
-  numFilesUploaded = 0;
+  invalidFiles: string[] = [];
+  filesPreview: string[] = [];
   uploading = false;
-
-  updateImportedKeystores(jsonFile: object): void {
-    const imported = this.formGroup?.get('keystoresImported')?.value;
-    this.formGroup?.get('keystoresImported')?.setValue([...imported, JSON.stringify(jsonFile)]);
-  }
 
   // Unzip an uploaded zip file and attempt
   // to get all its keystores to update the form group.
@@ -36,7 +29,7 @@ export class ImportAccountsFormComponent {
         blob.forEach(async (item) => {
           const res = await blob.file(item)?.async('string');
           if (res) {
-            this.updateImportedKeystores(JSON.parse(res));
+            this.updateImportedKeystores(item, JSON.parse(res));
           }
         });
       }),
@@ -46,27 +39,62 @@ export class ImportAccountsFormComponent {
     ).subscribe();
   }
 
-  dropped(files: NgxFileDropEntry[]): void {
-    this.files = this.files.concat(files);
-    this.filesPreview = this.files.slice(0, this.MAX_FILES_BEFORE_PREVIEW);
-    this.totalFiles = this.files.length;
+  dropped(droppedFiles: NgxFileDropEntry[]): void {
     this.uploading = true;
-    for (const droppedFile of files) {
+    let numFilesUploaded = 0;
+    this.invalidFiles = [];
+    for (const droppedFile of droppedFiles) {
       if (droppedFile.fileEntry.isFile) {
         const fileEntry = droppedFile.fileEntry as FileSystemFileEntry;
         fileEntry.file(async (file: File) => {
           const text = await file.text();
-          this.numFilesUploaded++;
-          if (this.numFilesUploaded === this.totalFiles) {
+          numFilesUploaded++;
+          if (numFilesUploaded ===  droppedFiles.length) {
             this.uploading = false;
           }
           if (file.type === 'application/zip') {
             this.unzipFile(file);
           } else {
-            this.updateImportedKeystores(JSON.parse(text));
+            this.updateImportedKeystores(file.name, JSON.parse(text));
           }
         });
       }
     }
+  }
+
+  private updateImportedKeystores(fileName: string, jsonFile: object): void {
+    if (!this.isKeystoreFileValid(jsonFile)) {
+      this.invalidFiles.push('Invalid Format: ' + fileName);
+      return;
+    }
+    
+    const imported = this.formGroup?.get('keystoresImported')?.value as string[];
+    const jsonString = JSON.stringify(jsonFile);
+    if (imported.includes(jsonString)) {
+      this.invalidFiles.push('Duplicate: ' + fileName);
+      return;
+    }
+
+    this.filesPreview.push(fileName);
+    this.formGroup?.get('keystoresImported')?.setValue([...imported, jsonString]);
+  }
+
+  private isKeystoreFileValid(jsonFile: object): boolean {
+    // Keystores are by definition an array, so exit early.
+    if (!Array.isArray(jsonFile)) {
+      return false;
+    }
+    
+    // Lazy way checking if the attributes exists.
+    return (jsonFile as Array<Object>).every(item => 
+        'pubkey' in item
+        && 'withdrawal_credentials' in item
+        && 'amount' in item
+        && 'signature' in item
+        && 'deposit_message_root' in item
+        && 'deposit_data_root' in item
+        && 'fork_version' in item
+        && 'eth2_network_name' in item
+        && 'deposit_cli_version' in item);
   }
 }

--- a/src/app/modules/system-process/pages/logs/logs.component.spec.ts
+++ b/src/app/modules/system-process/pages/logs/logs.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LogsComponent } from './logs.component';
 import { SharedModule } from '../../../shared/shared.module';
-import { LogsService } from '../../services/logs.service';
+import { LogsService } from '../../../core/services/logs.service';
 import { MockComponent, MockService } from 'ng-mocks';
 import { of } from 'rxjs';
 import { LogsStreamComponent } from '../../components/logs-stream/logs-stream.component';


### PR DESCRIPTION
- Makes sure no duplicates of keys can be added.
- Invalid keys that don't have the attributes will not be added.
- Created a error section that shows the incorrect keys.
- Cleaned up the code a little, many public attributes not needed.
- This allows dropping the entire folder.

Fixes #110