### PR TITLE
Error Messages: Show the inner errors

### DIFF
--- a/src/app/modules/core/services/error.service.ts
+++ b/src/app/modules/core/services/error.service.ts
@@ -13,7 +13,7 @@ export class ErrorService {
 
   handleHTTPError(err: HttpErrorResponse): void {
     this.zone.run(() => {
-      this.snackBar.open(err.message, 'Close', {
+      this.snackBar.open(err.error?.message || err.message, 'Close', {
         duration: 4000,
         panelClass: 'snackbar-warn',
       });


### PR DESCRIPTION
When an error object has an inner message, it is a much more
user friendly than the http error. Showcase that for the snackbar.

This will transform HTTP Errors to meaningful errors.

Fixes #118 