### PR TITLE
Fix auth redirects to respect the return URL.

### DIFF
--- a/src/app/modules/auth/login/login.component.ts
+++ b/src/app/modules/auth/login/login.component.ts
@@ -40,7 +40,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     // return url is set in the query parameters.
     this.route.queryParams.pipe(
       takeUntil(this.destroyed$),
-    ).subscribe(params => this.returnUrl = params.return || '/onboarding');
+    ).subscribe(params => this.returnUrl = params.returnUrl || '/onboarding');
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/core/guards/auth.guard.spec.ts
+++ b/src/app/modules/core/guards/auth.guard.spec.ts
@@ -52,7 +52,7 @@ describe('AuthGuard', () => {
       authService.token = '';
       env.env.production = true;
       expect(guard.canActivate(next, state)).toEqual(false);
-      expect(router.navigate).toHaveBeenCalledWith(['/login']);
+      expect(router.navigate).toHaveBeenCalledWith(['/']);
     });
   });
 });

--- a/src/app/modules/core/guards/auth.guard.spec.ts
+++ b/src/app/modules/core/guards/auth.guard.spec.ts
@@ -52,7 +52,7 @@ describe('AuthGuard', () => {
       authService.token = '';
       env.env.production = true;
       expect(guard.canActivate(next, state)).toEqual(false);
-      expect(router.navigate).toHaveBeenCalledWith(['/']);
+      expect(router.navigate).toHaveBeenCalledWith(['/login']);
     });
   });
 });

--- a/src/app/modules/core/guards/auth.guard.ts
+++ b/src/app/modules/core/guards/auth.guard.ts
@@ -22,12 +22,22 @@ export class AuthGuard implements CanActivate {
   canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
-  ): Observable<any> | Promise<boolean|UrlTree> | boolean{
+  ): Observable<any> | Promise<boolean|UrlTree> | boolean {
     const isDev = !this.environmenter.env.production;
     if (this.authenticationService.token || isDev) {
       return true;
     }
-    this.router.navigate(['/']);
+
+    if (state.url) {
+      this.router.navigate(['/login'],  {
+        queryParams: {
+          returnUrl: state.url
+        }
+      });
+    } else {
+      this.router.navigate(['/login']);
+    }
+
     return false;
   }
 }

--- a/src/app/modules/core/guards/auth.guard.ts
+++ b/src/app/modules/core/guards/auth.guard.ts
@@ -29,13 +29,13 @@ export class AuthGuard implements CanActivate {
     }
 
     if (state.url) {
-      this.router.navigate(['/'],  {
+      this.router.navigate(['/login'],  {
         queryParams: {
           returnUrl: state.url
         }
       });
     } else {
-      this.router.navigate(['/']);
+      this.router.navigate(['/login']);
     }
 
     return false;

--- a/src/app/modules/core/guards/auth.guard.ts
+++ b/src/app/modules/core/guards/auth.guard.ts
@@ -29,13 +29,13 @@ export class AuthGuard implements CanActivate {
     }
 
     if (state.url) {
-      this.router.navigate(['/login'],  {
+      this.router.navigate(['/'],  {
         queryParams: {
           returnUrl: state.url
         }
       });
     } else {
-      this.router.navigate(['/login']);
+      this.router.navigate(['/']);
     }
 
     return false;

--- a/src/app/modules/core/guards/auth.guard.ts
+++ b/src/app/modules/core/guards/auth.guard.ts
@@ -29,7 +29,7 @@ export class AuthGuard implements CanActivate {
     }
 
     if (state.url) {
-      this.router.navigate(['/login'],  {
+      this.router.navigate(['/login'], {
         queryParams: {
           returnUrl: state.url
         }


### PR DESCRIPTION
When the user refreshes the screen or authentication token is
invalid, the redirect URL was incorrect and always defaulting to
the root page.

This change fixes a bug where it was using `this.return` instead
of `this.returnUrl` and fixes the AuthGuard to actually put back
the URL state when redirecting.

Redirecting back to `/login` is needed when the auth token is 
not there because that is where the logic happens to determine
which URL is to redirect otherwise that URLParameters would be 
lost.

Fixes #120
Part of #116 