### PR TITLE
Utilize NDJson Streams to Process Logs from the Validator Backend

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,7 +37,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
-    { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
+    // { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
     { provide: ENVIRONMENT, useValue: environment },
   ],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,7 +37,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
-    // { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
     { provide: ENVIRONMENT, useValue: environment },
   ],
   bootstrap: [AppComponent]

--- a/src/app/modules/core/constants.ts
+++ b/src/app/modules/core/constants.ts
@@ -8,7 +8,5 @@ export const MAX_ALLOWED_KEYSTORES = 50;
 export const MAX_ACCOUNTS_CREATION = 50;
 export const DIALOG_WIDTH = '600px';
 export const BEACONCHAIN_EXPLORER = 'https://beaconcha.in';
-export const VALIDATOR_WS_ENDPOINT = 'ws://localhost:8081/logs';
-export const BEACON_WS_ENDPOINT = 'ws://localhost:8080/logs';
 export const WS_RECONNECT_INTERVAL = 3000;
 export const GEO_COORDINATES_API = 'http://ip-api.com/batch';

--- a/src/app/modules/core/services/logs.service.ts
+++ b/src/app/modules/core/services/logs.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { stream } from '../../core/utils/ndjson';
 import { Observable, of } from 'rxjs';
 import { concatMap, delay, map, mergeAll } from 'rxjs/operators';
+
+import { stream } from '../../core/utils/ndjson';
 import { EnvironmenterService } from '../../core/services/environmenter.service';
 import { mockBeaconLogs, mockValidatorLogs } from 'src/app/modules/core/mocks/logs';
 

--- a/src/app/modules/core/services/logs.service.ts
+++ b/src/app/modules/core/services/logs.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { stream } from '../../core/utils/ndjson';
 import { Observable, of, timer } from 'rxjs';
 import { webSocket } from 'rxjs/webSocket';
 import { concatMap, delay, delayWhen, mergeAll, retryWhen, switchMap, tap } from 'rxjs/operators';
@@ -7,15 +8,22 @@ import { mockBeaconLogs, mockValidatorLogs } from 'src/app/modules/core/mocks/lo
 import { WS_RECONNECT_INTERVAL } from '../../core/constants';
 import { ValidatorService } from './validator.service';
 import { LogsEndpointResponse } from 'src/app/proto/validator/accounts/v2/web_api';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root'
 })
 export class LogsService {
   constructor(
+    private http: HttpClient,
     private validatorService: ValidatorService,
     private environmenter: EnvironmenterService,
   ) { }
+  private apiUrl = this.environmenter.env.validatorEndpoint;
+
+  streamValidatorLogs() {
+    return stream(`${this.apiUrl}/health/logs/validator/stream`);
+  }
 
   validatorLogs(): Observable<MessageEvent> {
     // Use mock data in development mode.

--- a/src/app/modules/core/services/logs.service.ts
+++ b/src/app/modules/core/services/logs.service.ts
@@ -27,7 +27,8 @@ export class LogsService {
       );
     }
     return stream(`${this.apiUrl}/health/logs/validator/stream`).pipe(
-      map(data => data.result.logs),
+      map(data => JSON.parse(data)),
+      map(obj => obj.result.logs),
       mergeAll(),
     );
   }
@@ -44,7 +45,8 @@ export class LogsService {
       );
     }
     return stream(`${this.apiUrl}/health/logs/beacon/stream`).pipe(
-      map(data => data.result.logs),
+      map(data => JSON.parse(data)),
+      map(obj => obj.result.logs),
       mergeAll(),
     );
   }

--- a/src/app/modules/core/services/logs.service.ts
+++ b/src/app/modules/core/services/logs.service.ts
@@ -1,36 +1,23 @@
 import { Injectable } from '@angular/core';
 import { stream } from '../../core/utils/ndjson';
-import { Observable, of, timer } from 'rxjs';
-import { webSocket } from 'rxjs/webSocket';
-import { concatMap, delay, delayWhen, mergeAll, retryWhen, switchMap, tap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { concatMap, delay, map, mergeAll } from 'rxjs/operators';
 import { EnvironmenterService } from '../../core/services/environmenter.service';
 import { mockBeaconLogs, mockValidatorLogs } from 'src/app/modules/core/mocks/logs';
-import { WS_RECONNECT_INTERVAL } from '../../core/constants';
-import { ValidatorService } from './validator.service';
-import { LogsEndpointResponse } from 'src/app/proto/validator/accounts/v2/web_api';
-import { HttpClient } from '@angular/common/http';
 
 @Injectable({
   providedIn: 'root'
 })
 export class LogsService {
   constructor(
-    private http: HttpClient,
-    private validatorService: ValidatorService,
     private environmenter: EnvironmenterService,
   ) { }
   private apiUrl = this.environmenter.env.validatorEndpoint;
 
-  streamValidatorLogs() {
-    return stream(`${this.apiUrl}/health/logs/validator/stream`);
-  }
-
-  validatorLogs(): Observable<MessageEvent> {
+  validatorLogs(): Observable<string> {
     // Use mock data in development mode.
     if (!this.environmenter.env.production) {
-      const data = mockValidatorLogs.split('\n').map((v, _) => {
-        return { data: v } as MessageEvent;
-      });
+      const data = mockValidatorLogs.split('\n').map((v, _) => v);
       return of(data).pipe(
         mergeAll(),
         concatMap(x => of(x).pipe(
@@ -38,17 +25,16 @@ export class LogsService {
         ))
       );
     }
-    return this.validatorService.logsEndpoints$.pipe(
-      switchMap((resp: LogsEndpointResponse) => this.connect(`ws://${resp.validatorLogsEndpoint}`)),
+    return stream(`${this.apiUrl}/health/logs/validator/stream`).pipe(
+      map(data => data.result.logs),
+      mergeAll(),
     );
   }
 
-  beaconLogs(): Observable<MessageEvent> {
+  beaconLogs(): Observable<string> {
     // Use mock data in development mode.
     if (!this.environmenter.env.production) {
-      const data = mockBeaconLogs.split('\n').map((v, _) => {
-        return { data: v } as MessageEvent;
-      });
+      const data = mockBeaconLogs.split('\n').map((v, _) => v);
       return of(data).pipe(
         mergeAll(),
         concatMap(x => of(x).pipe(
@@ -56,28 +42,9 @@ export class LogsService {
         ))
       );
     }
-    return this.validatorService.logsEndpoints$.pipe(
-      switchMap((resp: LogsEndpointResponse) => this.connect(`ws://${resp.beaconLogsEndpoint}`)),
-    );
-  }
-
-  private connect(url: string): Observable<MessageEvent> {
-    return webSocket({
-      url,
-      deserializer: msg => msg,
-    }).pipe(
-      this.reconnect,
-    );
-  }
-
-  private reconnect(observable: Observable<MessageEvent>): Observable<MessageEvent> {
-    return observable.pipe(
-      retryWhen(errors =>
-        errors.pipe(
-          tap((err) => console.error(`LogsService trying to reconnect: ${err}`)),
-          delayWhen(_ => timer(WS_RECONNECT_INTERVAL)),
-        )
-      ),
+    return stream(`${this.apiUrl}/health/logs/beacon/stream`).pipe(
+      map(data => data.result.logs),
+      mergeAll(),
     );
   }
 }

--- a/src/app/modules/core/utils/ndjson.ts
+++ b/src/app/modules/core/utils/ndjson.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 Julian Hall
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import { from, Observable, Subject } from 'rxjs';
+import { concatMap, filter, map, scan } from 'rxjs/operators';
+
+/*
+ * stream (url, options)
+ *
+ * Download line-delimited JSON from specified URL and deliver as an Observable.
+ * Options are: method - defaults to GET, postData - default none,
+ * xhrFactory - function to supply the XMLHttpRequest used (defaults to
+ * new XMLHttpRequest), and beforeOpen - function called before xhr.open() to
+ * allow for user-specified customization of the request.
+ */
+export function stream(url: string) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  var xhr = options.xhrFactory ? options.xhrFactory(url, options) : new XMLHttpRequest();
+
+  var textStream = extractStream(xhr);
+  var jsonStream = collate(textStream).pipe(
+    concatMap(function (lineArray: any[]) {
+      return from(lineArray);
+    }),
+    map((x: string, _) => JSON.parse(x)),
+  );
+
+  if (options.beforeOpen) options.beforeOpen(xhr);
+
+  xhr.open(options.method ? options.method : "GET", url);
+  xhr.send(options.postData ? options.postData : null);
+
+  return jsonStream;
+}
+
+/*
+ * collate(stream)
+ *
+ * Translate a stream of chunks of text into a stream of arrays of lines of text.
+ * Does not include any text after the last newline, so ensure the input is
+ * newline-terminated as well as delimited.
+ */
+function collate(stream: Observable<any>) {
+  return stream.pipe(
+    scan((state: any, data: string) => {
+      let index = data.lastIndexOf('\n');
+      if (index >= 0) {
+          return {
+              finishedLine: state.buffer + data.substring(0, index + 1),
+              buffer: data.substring(index + 1)
+          };
+      } else {
+        return { buffer: data };
+      }
+    }, { buffer: '' }),
+    filter((x: any) => x.finishedLine),
+    map((x: any) => {
+      return x.finishedLine.split('\n').filter((i: string) => i.length > 0);
+    })
+  );
+}
+
+/*
+ * extractStream (xhr, [options])
+ *
+ * Listen to download progress events on an XMLHttpRequest and provide the
+ * response text in chunks as it is downloaded.  Options can contain the
+ * flag "endWithNewline: true" which adds a trailing newline if one did not
+ * exist in the source.
+ */
+function extractStream(xhr: XMLHttpRequest) {
+  let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  return Observable.create((observer: Subject<any>) => {
+    let charactersSeen = 0;
+    function notified() {
+        if (xhr.readyState >= 3 && xhr.responseText.length > charactersSeen) {
+            observer.next(xhr.responseText.substring(charactersSeen));
+            charactersSeen = xhr.responseText.length;
+        }
+        if (xhr.readyState == 4) {
+            if (options.endWithNewline && xhr.responseText[xhr.responseText.length - 1] != "\n") observer.next("\n");
+            observer.complete();
+        }
+    }
+    xhr.onreadystatechange = notified;
+    xhr.onprogress = notified;
+    xhr.onerror = event => {
+      observer.error(event);
+    };
+  });
+}

--- a/src/app/modules/system-process/pages/logs/logs.component.spec.ts
+++ b/src/app/modules/system-process/pages/logs/logs.component.spec.ts
@@ -30,8 +30,8 @@ describe('LogsComponent', () => {
   }));
 
   beforeEach(() => {
-    service.beaconLogs = () => of({} as MessageEvent);
-    service.validatorLogs = () => of({} as MessageEvent);
+    service.beaconLogs = () => of('');
+    service.validatorLogs = () => of('');
     fixture = TestBed.createComponent(LogsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/modules/system-process/pages/logs/logs.component.ts
+++ b/src/app/modules/system-process/pages/logs/logs.component.ts
@@ -40,26 +40,18 @@ export class LogsComponent implements OnInit, OnDestroy {
   }
 
   private subscribeLogs(): void {
-    console.log('try stream');
-    this.logsService.streamValidatorLogs().pipe(
-      takeUntil(this.destroyed$$),
-      tap((msg) => {
-        console.log('got message');
-        console.log(msg);
-      }),
-    ).subscribe();
     this.logsService.validatorLogs().pipe(
       takeUntil(this.destroyed$$),
-      tap((msg: MessageEvent) => {
-        this.validatorMessages.push(msg.data);
-        this.countLogMetrics(msg.data);
+      tap((msg: string) => {
+        this.validatorMessages.push(msg);
+        this.countLogMetrics(msg);
       })
     ).subscribe();
     this.logsService.beaconLogs().pipe(
       takeUntil(this.destroyed$$),
-      tap((msg: MessageEvent) => {
-        this.beaconMessages.push(msg.data);
-        this.countLogMetrics(msg.data);
+      tap((msg: string) => {
+        this.beaconMessages.push(msg);
+        this.countLogMetrics(msg);
       })
     ).subscribe();
   }

--- a/src/app/modules/system-process/pages/logs/logs.component.ts
+++ b/src/app/modules/system-process/pages/logs/logs.component.ts
@@ -40,6 +40,14 @@ export class LogsComponent implements OnInit, OnDestroy {
   }
 
   private subscribeLogs(): void {
+    console.log('try stream');
+    this.logsService.streamValidatorLogs().pipe(
+      takeUntil(this.destroyed$$),
+      tap((msg) => {
+        console.log('got message');
+        console.log(msg);
+      }),
+    ).subscribe();
     this.logsService.validatorLogs().pipe(
       takeUntil(this.destroyed$$),
       tap((msg: MessageEvent) => {


### PR DESCRIPTION
This PR consolidates the backend endpoints into the single validator backend API handler by retrieving logs via new-line delimited JSON streams from the backend. We customized the https://github.com/jh3141/ndjson-rxjs#readme package to play nice with typescript and latest version of rxjs to achieve this.

Fixes #94 