### PR TITLE
Fixes error interceptor redirect when API returns 401

### DIFF
--- a/src/app/modules/auth/login/login.component.ts
+++ b/src/app/modules/auth/login/login.component.ts
@@ -40,9 +40,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     // return url is set in the query parameters.
     this.route.queryParams.pipe(
       takeUntil(this.destroyed$),
-    ).subscribe(params => {
-      this.returnUrl = params.returnUrl || '/onboarding';
-    });
+    ).subscribe(params => this.returnUrl = params.returnUrl || '/onboarding');
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/auth/login/login.component.ts
+++ b/src/app/modules/auth/login/login.component.ts
@@ -40,7 +40,9 @@ export class LoginComponent implements OnInit, OnDestroy {
     // return url is set in the query parameters.
     this.route.queryParams.pipe(
       takeUntil(this.destroyed$),
-    ).subscribe(params => this.returnUrl = params.returnUrl || '/onboarding');
+    ).subscribe(params => {
+      this.returnUrl = params.returnUrl || '/onboarding';
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/core/interceptors/error.interceptor.spec.ts
+++ b/src/app/modules/core/interceptors/error.interceptor.spec.ts
@@ -7,17 +7,22 @@ import { AuthenticationService } from '../services/authentication.service';
 import { ErrorService } from '../services/error.service';
 import { RouterTestingModule } from '@angular/router/testing';
 
+class TestComponent {
+}
+
 describe('ErrorInterceptor', () => {
   let authService: AuthenticationService;
   let errorService: ErrorService;
 
   beforeEach(() => {
-    const serviceSpy = jasmine.createSpyObj('AuthenticationService', ['logout']);
+    const serviceSpy = jasmine.createSpyObj('AuthenticationService', ['clearCredentials']);
     const errorSpy = jasmine.createSpyObj('ErrorService', ['handleHTTPError']);
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
-        RouterTestingModule,
+        RouterTestingModule.withRoutes([
+          { path: 'login', component: TestComponent}
+        ]),
       ],
       providers: [
         {
@@ -31,7 +36,7 @@ describe('ErrorInterceptor', () => {
     });
     authService = TestBed.inject(AuthenticationService);
     errorService = TestBed.inject(ErrorService);
-    authService.logout = jasmine.createSpy('logout');
+    authService.clearCredentials = jasmine.createSpy('clearCredentials');
   });
 
   describe('intercept HTTP requests', () => {
@@ -48,7 +53,7 @@ describe('ErrorInterceptor', () => {
 
         req.flush({ errorMessage: 'Oh no' }, { status: 401, statusText: 'Unauthorized' });
         mock.verify();
-        expect(authService.logout).toHaveBeenCalled();
+        expect(authService.clearCredentials).toHaveBeenCalled();
       })
     );
 
@@ -65,7 +70,7 @@ describe('ErrorInterceptor', () => {
 
         req.flush({ errorMessage: 'Oh no' }, { status: 500, statusText: 'Internal Server Error' });
         mock.verify();
-        expect(authService.logout).not.toHaveBeenCalled();
+        expect(authService.clearCredentials).not.toHaveBeenCalled();
         expect(errorService.handleHTTPError).toHaveBeenCalled();
       })
     );

--- a/src/app/modules/core/interceptors/error.interceptor.ts
+++ b/src/app/modules/core/interceptors/error.interceptor.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpErrorResponse } from '@angular/common/http';
+import { Router } from '@angular/router';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -9,18 +10,23 @@ import { ErrorService } from '../services/error.service';
 @Injectable()
 export class ErrorInterceptor implements HttpInterceptor {
   constructor(
+    private router: Router,
     private authenticationService: AuthenticationService,
     private errorService: ErrorService,
   ) { }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(catchError((err: HttpErrorResponse) => {
-      if (err.status === 401) {
-        // Auto logout if a 401 response (Unauthorized)
-        // is returned from the api.
-        this.authenticationService.logout();
-      }
       this.errorService.handleHTTPError(err);
+      if (err.status === 401) {
+        // Auto logout if a 401 response (Unauthorized) is returned from the api.
+        this.authenticationService.clearCredentials();
+        this.router.navigate(['/login'],  {
+          queryParams: {
+            returnUrl: this.router.url
+          }
+        });
+      }
       return throwError(err);
     }));
   }

--- a/src/app/modules/core/services/authentication.service.ts
+++ b/src/app/modules/core/services/authentication.service.ts
@@ -54,12 +54,16 @@ export class AuthenticationService {
 
   // Logout the user and navigate to the application root.
   logout(): void {
-    this.token = '';
+    this.clearCredentials();
     this.http.post<unknown>(`${this.apiUrl}/logout`, null).pipe(
       tap(() => {
         this.router.navigateByUrl('/');
       }),
       switchMap(_ => EMPTY),
     );
+  }
+
+  clearCredentials(): void {
+    this.token = '';
   }
 }


### PR DESCRIPTION
 Angular HTTP Client doesn't let you issue another request when
 requesting the next URL unless you add it to the queue, which is
 not what we are doing. So instead, if the service is coming back
 as 401, we can redirect the user back automatically to the login
 page with the return URL in tact.

 The return URL is needed to create a positive experience instead
 navigating back where they are coming from after logging back in.

 Fixes #109
 Part of #116