### PR TITLE
Less Intrusive Peers Map Zoom

### DIFF
--- a/src/app/modules/core/services/geo-locator.service.ts
+++ b/src/app/modules/core/services/geo-locator.service.ts
@@ -20,7 +20,8 @@ export class GeoLocatorService {
 
   constructor(
     private http: HttpClient,
-    private beaconService: BeaconNodeService) { }
+    private beaconService: BeaconNodeService,
+  ) { }
 
   // http request
   getPeerCoordinates(): Observable<GeoCoordinate[]> {

--- a/src/app/modules/system-process/pages/peer-locations-map/peer-locations-map.component.ts
+++ b/src/app/modules/system-process/pages/peer-locations-map/peer-locations-map.component.ts
@@ -24,9 +24,12 @@ export class PeerLocationsMapComponent implements OnInit {
           const cityMarker: { [id: string]: ILMarker; } = {};
           const cityCounter: { [id: string]: number; } = {};
           geoCoordnates.forEach((coord: GeoCoordinate) => {
+            console.log(coord.lat, coord.lon);
             if (!cityCounter[coord.city]) {
+              const approxLat = Math.floor(coord.lat);
+              const approxLon = Math.floor(coord.lon);
               cityCounter[coord.city] = 1;
-              cityMarker[coord.city] = L.marker([coord.lat, coord.lon], new LMarkerConfig(mapIcon));
+              cityMarker[coord.city] = L.marker([approxLat, approxLon], new LMarkerConfig(mapIcon));
               cityMarker[coord.city].bindTooltip(coord.city).addTo(locationMap);
             }
             else {


### PR DESCRIPTION
No tracking issue. This PR adjusts the zoom level of lat + long in the peers map to not show the peers down to their street address. Users were quite scared when they saw how accurate the map was