### PR TITLE
Persist Authentication Token in Session Storage

### DIFF
--- a/src/app/modules/core/services/authentication.service.ts
+++ b/src/app/modules/core/services/authentication.service.ts
@@ -22,7 +22,7 @@ export class AuthenticationService {
   get token(): string | null {
     return sessionStorage.getItem('token');
   }
-  
+
   login(password: string): Observable<AuthResponse> {
     return this.authenticate(`${this.apiUrl}/login`, password);
   }

--- a/src/app/modules/core/services/authentication.service.ts
+++ b/src/app/modules/core/services/authentication.service.ts
@@ -16,10 +16,13 @@ export class AuthenticationService {
     private environmenter: EnvironmenterService,
   ) {
   }
-  token = '';
   hasSignedUp = false;
   private apiUrl = this.environmenter.env.validatorEndpoint;
 
+  get token(): string | null {
+    return sessionStorage.getItem('token');
+  }
+  
   login(password: string): Observable<AuthResponse> {
     return this.authenticate(`${this.apiUrl}/login`, password);
   }
@@ -27,7 +30,7 @@ export class AuthenticationService {
   signup(request: AuthRequest): Observable<AuthResponse> {
     return this.http.post<AuthResponse>(`${this.apiUrl}/signup`, request).pipe(
       tap((res: AuthResponse) => {
-        this.token = res.token;
+        sessionStorage.setItem('token', res.token);
       }),
     );
   }
@@ -47,7 +50,7 @@ export class AuthenticationService {
   authenticate(method: string, password: string): Observable<AuthResponse> {
     return this.http.post<AuthResponse>(method, { password } as AuthRequest).pipe(
       tap((res: AuthResponse) => {
-        this.token = res.token;
+        sessionStorage.setItem('token', res.token);
       }),
     );
   }
@@ -64,6 +67,6 @@ export class AuthenticationService {
   }
 
   clearCredentials(): void {
-    this.token = '';
+    sessionStorage.clear();
   }
 }


### PR DESCRIPTION
When refreshing the page, the token is lost since it was saved
in memory. By using session storage, we can ensure that browser
session will keep the token there until they close the tab.

In the future we can move this to localStorage if we have a way
to validate the token expiration and renew the token.

For #116