### PR TITLE
Making Password field in Signup process more clear

### DIFF
--- a/src/app/modules/auth/signup/signup.component.html
+++ b/src/app/modules/auth/signup/signup.component.html
@@ -12,7 +12,7 @@
               <input
                 matInput
                 formControlName="password"
-                placeholder="Enter your password for Prysm web"
+                placeholder="Enter a password for Prysm web"
                 name="password"
                 type="password"
               />


### PR DESCRIPTION
Making it more clear that it's a new password, as opposed to an existing password, that should be set during signup process.