### PR TITLE
Bump Ethers 5.0.12 to 5.0.30 for CVE-2020-28498

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/file-saver": "^2.0.1",
     "ansi_up": "^4.0.4",
     "echarts": "^4.8.0",
-    "ethers": "^5.0.12",
+    "ethers": "^5.0.30",
     "file-saver": "^2.0.2",
     "jszip": "^3.5.0",
     "leaflet": "^1.7.1",


### PR DESCRIPTION
Ethers < 5.0.30 used Elliptic.js 6.5.3 which did not check to ensure that the public key passed in to ECDH is a point that actually exists on the curve.
This opens up for a twist attack which could be used to reveal the private key of a party in an ECDH operation over a number of occurances.
https://github.com/ethers-io/ethers.js/pull/1284

https://github.com/christianlundkvist/blog/blob/master/2020_05_26_secp256k1_twist_attacks/secp256k1_twist_attacks.md
CVE: CVE-2020-28498