### PR TITLE
Account voluntary exit Pr with migrating wallet module to be lazy loaded

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -23,18 +23,22 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets",
-              "src/_redirects"
+            "allowedCommonJsDependencies": [
+              "ethers/lib/utils",
+              "rxjs-pipe-ext/lib",
+              "ansi_up",
+              "hash.js",
+              "zrender/lib/svg/svg",
+              "bn.js",
+              "echarts",
+              "zrender/lib/vml/vml"
             ],
+            "assets": ["src/favicon.ico", "src/assets", "src/_redirects"],
             "styles": [
               "src/styles.scss",
               "./node_modules/leaflet/dist/leaflet.css"
             ],
-            "scripts": [
-              "./node_modules/leaflet/dist/leaflet.js"
-            ]
+            "scripts": ["./node_modules/leaflet/dist/leaflet.js"]
           },
           "configurations": {
             "production": {
@@ -70,7 +74,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "prysm-web-ui:build",
+            "browserTarget": "prysm-web-ui:build"
           },
           "configurations": {
             "production": {
@@ -91,13 +95,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },
@@ -109,9 +108,7 @@
               "tsconfig.spec.json",
               "e2e/tsconfig.json"
             ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -127,6 +124,10 @@
           }
         }
       }
-    }},
-  "defaultProject": "prysm-web-ui"
+    }
+  },
+  "defaultProject": "prysm-web-ui",
+  "cli": {
+    "analytics": "febbd90d-29bb-408a-9067-7df1e10d85dc"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "prestart": "ngtw build",
     "start": "ng serve --live-reload && ngtw watch",
     "start:staging": "ng serve --prod=true --live-reload && ngtw watch",
-    "build": "ng build",
+    "build":"ng build",
     "build:dev": "ngtw build && ng build --prod=false",
     "build:prod": "ngtw build && ng build --prod=true",
     "clean": "rm -Rf ./dist",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "prestart": "ngtw build",
     "start": "ng serve --live-reload && ngtw watch",
     "start:staging": "ng serve --prod=true --live-reload && ngtw watch",
+    "build": "ng build",
     "build:dev": "ngtw build && ng build --prod=false",
     "build:prod": "ngtw build && ng build --prod=true",
     "clean": "rm -Rf ./dist",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,9 +7,6 @@ import { LogsComponent } from './modules/system-process/pages/logs/logs.componen
 import { MetricsComponent } from './modules/system-process/pages/metrics/metrics.component';
 import { ChangePasswordComponent } from './modules/security/pages/change-password/change-password.component';
 import { OnboardingComponent } from './modules/onboarding/onboarding.component';
-import { WalletDetailsComponent } from './modules/wallet/pages/wallet-details/wallet-details.component';
-import { AccountsComponent } from './modules/wallet/pages/accounts/accounts.component';
-import { ImportComponent } from './modules/wallet/pages/import/import.component';
 import { PeerLocationsMapComponent } from './modules/system-process/pages/peer-locations-map/peer-locations-map.component';
 import { InitializeComponent } from './modules/auth/initialize/initialize.component';
 
@@ -26,14 +23,14 @@ const routes: Routes = [
   {
     path: 'onboarding',
     data: {
-      breadcrumb: 'Onboarding'
+      breadcrumb: 'Onboarding',
     },
     component: OnboardingComponent,
   },
   {
     path: 'dashboard',
     data: {
-      breadcrumb: 'Dashboard'
+      breadcrumb: 'Dashboard',
     },
     component: DashboardComponent,
     children: [
@@ -45,49 +42,17 @@ const routes: Routes = [
       {
         path: 'gains-and-losses',
         data: {
-          breadcrumb: 'Gains & Losses'
+          breadcrumb: 'Gains & Losses',
         },
         component: GainsAndLossesComponent,
       },
+
       {
         path: 'wallet',
-        data: {
-          breadcrumb: 'Wallet'
-        },
-        children: [
-          {
-            path: '',
-            redirectTo: 'accounts',
-            pathMatch: 'full',
-          },
-          {
-            path: 'accounts',
-            data: {
-              breadcrumb: 'Accounts',
-            },
-            children: [
-              {
-                path: '',
-                component: AccountsComponent,
-              },
-            ],
-          },
-          {
-            path: 'details',
-            data: {
-              breadcrumb: 'Wallet Details'
-            },
-            component: WalletDetailsComponent,
-          },
-          {
-            path: 'import',
-            data: {
-              breadcrumb: 'Import Accounts'
-            },
-            component: ImportComponent,
-          },
-        ]
+        loadChildren: () =>
+          import('./modules/wallet/wallet.module').then((m) => m.WalletModule),
       },
+
       {
         path: 'system',
         data: {
@@ -102,25 +67,25 @@ const routes: Routes = [
           {
             path: 'logs',
             data: {
-              breadcrumb: 'Process Logs'
+              breadcrumb: 'Process Logs',
             },
             component: LogsComponent,
           },
           {
             path: 'metrics',
             data: {
-              breadcrumb: 'Process Metrics'
+              breadcrumb: 'Process Metrics',
             },
             component: MetricsComponent,
           },
           {
             path: 'peers-map',
             data: {
-              breadcrumb: 'Peer locations map'
+              breadcrumb: 'Peer locations map',
             },
             component: PeerLocationsMapComponent,
-          }
-        ]
+          },
+        ],
       },
       {
         path: 'security',
@@ -136,18 +101,18 @@ const routes: Routes = [
           {
             path: 'change-password',
             data: {
-              breadcrumb: 'Change Password'
+              breadcrumb: 'Change Password',
             },
             component: ChangePasswordComponent,
           },
-        ]
-      }
-    ]
-  }
+        ],
+      },
+    ],
+  },
 ];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,19 +16,18 @@ import { OnboardingModule } from './modules/onboarding/onboarding.module';
 import { SystemProcessModule } from './modules/system-process/system-process.module';
 import { MockInterceptor } from './modules/core/interceptors/mock.interceptor';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
-  declarations: [
-    AppComponent
-  ],
+  declarations: [AppComponent],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     AppRoutingModule,
     HttpClientModule,
     AuthModule,
     DashboardModule,
     NgxSkeletonLoaderModule,
-    WalletModule,
     OnboardingModule,
     SystemProcessModule,
     SecurityModule,
@@ -38,6 +37,6 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
     { provide: HTTP_INTERCEPTORS, useClass: MockInterceptor, multi: true },
     { provide: ENVIRONMENT, useValue: environment },
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/modules/auth/auth.module.ts
+++ b/src/app/modules/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { SharedModule } from '../../modules/shared/shared.module';
 import { LoginComponent } from './login/login.component';
 import { InitializeComponent } from './initialize/initialize.component';
 import { SignupComponent } from './signup/signup.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [LoginComponent, InitializeComponent, SignupComponent],
@@ -15,6 +16,7 @@ import { SignupComponent } from './signup/signup.component';
     FormsModule,
     ReactiveFormsModule,
     RouterModule,
+    BrowserAnimationsModule,
     SharedModule,
   ]
 })

--- a/src/app/modules/auth/login/login.component.spec.ts
+++ b/src/app/modules/auth/login/login.component.spec.ts
@@ -9,6 +9,7 @@ import { LoginComponent } from './login.component';
 import { SharedModule } from '../../shared/shared.module';
 import { AuthenticationService } from '../../core/services/authentication.service';
 import { MatDialogRef } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -23,6 +24,7 @@ describe('LoginComponent', () => {
         RouterTestingModule,
         FormsModule,
         ReactiveFormsModule,
+        BrowserAnimationsModule,
         SharedModule,
       ],
       providers: [

--- a/src/app/modules/auth/signup/signup.component.spec.ts
+++ b/src/app/modules/auth/signup/signup.component.spec.ts
@@ -9,6 +9,7 @@ import { SignupComponent } from './signup.component';
 import { SharedModule } from '../../shared/shared.module';
 import { AuthenticationService } from '../../core/services/authentication.service';
 import { MatDialogRef } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('SignupComponent', () => {
   let component: SignupComponent;
@@ -24,6 +25,7 @@ describe('SignupComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         SharedModule,
+        BrowserAnimationsModule
       ],
       providers: [
         Overlay,

--- a/src/app/modules/core/mocks/index.ts
+++ b/src/app/modules/core/mocks/index.ts
@@ -116,6 +116,7 @@ export const generateBalancesForEpoch = (url: string) => {
 
 export const Mocks: IMocks = {
   '/v2/validator/wallet/recover': {},
+  '/v2/validator/wallet/account/exit': {},
   '/v2/validator/login': {
     token: 'mock.jwt.token',
   } as AuthResponse,

--- a/src/app/modules/core/mocks/index.ts
+++ b/src/app/modules/core/mocks/index.ts
@@ -29,41 +29,67 @@ export interface IMocks {
 }
 
 export const mockPublicKeys: string[] = [
-  hexToBase64('0xaadaf653799229200378369ee7d6d9fdbdcdc2788143ed44f1ad5f2367c735e83a37c5bb80d7fb917de73a61bbcf00c4'),
-  hexToBase64('0xb9a7565e5daaabf7e5656b64201685c6c0241df7195a64dcfc82f94b39826562208ea663dc8e340994fe5e2eef05967a'),
-  hexToBase64('0xa74a19ce0c8a7909cb38e6645738c8d3f85821e371ecc273f16d02ec8b279153607953522c61e0d9c16c73e4e106dd31'),
-  hexToBase64('0x8d4d65e320ebe3f8f45c1941a7f340eef43ff233400253a5532ad40313b4c5b3652ad84915c7ab333d8afb336e1b7407'),
-  hexToBase64('0x93b283992d2db593c40d0417ccf6302ed5a26180555ec401c858232dc224b7e5c92aca63646bbf4d0d61df1584459d90'),
+  hexToBase64(
+    '0xaadaf653799229200378369ee7d6d9fdbdcdc2788143ed44f1ad5f2367c735e83a37c5bb80d7fb917de73a61bbcf00c4'
+  ),
+  hexToBase64(
+    '0xb9a7565e5daaabf7e5656b64201685c6c0241df7195a64dcfc82f94b39826562208ea663dc8e340994fe5e2eef05967a'
+  ),
+  hexToBase64(
+    '0xa74a19ce0c8a7909cb38e6645738c8d3f85821e371ecc273f16d02ec8b279153607953522c61e0d9c16c73e4e106dd31'
+  ),
+  hexToBase64(
+    '0x8d4d65e320ebe3f8f45c1941a7f340eef43ff233400253a5532ad40313b4c5b3652ad84915c7ab333d8afb336e1b7407'
+  ),
+  hexToBase64(
+    '0x93b283992d2db593c40d0417ccf6302ed5a26180555ec401c858232dc224b7e5c92aca63646bbf4d0d61df1584459d90'
+  ),
 ];
 
 const mockImportedKeys: string[] = [
-  hexToBase64('0x80027c7b2213480672caf8503b82d41ff9533ba3698c2d70d33fa6c1840b2c115691dfb6de791f415db9df8b0176b9e4'),
-  hexToBase64('0x800212f3ac97227ac9e4418ce649f386d90bbc1a95c400b6e0dbbe04da2f9b970e85c32ae89c4fdaaba74b5a2934ed5e'),
+  hexToBase64(
+    '0x80027c7b2213480672caf8503b82d41ff9533ba3698c2d70d33fa6c1840b2c115691dfb6de791f415db9df8b0176b9e4'
+  ),
+  hexToBase64(
+    '0x800212f3ac97227ac9e4418ce649f386d90bbc1a95c400b6e0dbbe04da2f9b970e85c32ae89c4fdaaba74b5a2934ed5e'
+  ),
 ];
 
 export const mockDepositDataJSON = [
   {
-    pubkey: '887c846ea05cd65ee903c7c99bd5a171005f8081d940e05d70f9c0814e66e3a721e0b2d485ad80c87ce8c7e5a6693fa2',
-    withdrawalCredentials: '009b3b7a7e3e642645f6cb50dfaf3e139899c5baf4821e09490601395787f45e',
+    pubkey:
+      '887c846ea05cd65ee903c7c99bd5a171005f8081d940e05d70f9c0814e66e3a721e0b2d485ad80c87ce8c7e5a6693fa2',
+    withdrawalCredentials:
+      '009b3b7a7e3e642645f6cb50dfaf3e139899c5baf4821e09490601395787f45e',
     amount: 32000000000,
-    signature: '85dbbf537ef846b8995f886e593e433b69f34753b7b34e0d131c091f3b1234cba649d844aaa362d707d4641c6eb9f4f5018c35e05b48db3bb9fc24592dd3b45735cdd7321ad017e2fdad949b0f004a855901788611fd586483cba137702bb022',
-    depositMessageRoot: '273656cacb66e0bcb62ea3b59b565ea7dc52552b00e458ba13f785a0751bf8bd',
-    depositDataRoot: 'c66bb8bd4226ba48b6d3cf41be1135650beb31638ffb82f83023462e49cf110d',
-    forkVersion: '00000001'
+    signature:
+      '85dbbf537ef846b8995f886e593e433b69f34753b7b34e0d131c091f3b1234cba649d844aaa362d707d4641c6eb9f4f5018c35e05b48db3bb9fc24592dd3b45735cdd7321ad017e2fdad949b0f004a855901788611fd586483cba137702bb022',
+    depositMessageRoot:
+      '273656cacb66e0bcb62ea3b59b565ea7dc52552b00e458ba13f785a0751bf8bd',
+    depositDataRoot:
+      'c66bb8bd4226ba48b6d3cf41be1135650beb31638ffb82f83023462e49cf110d',
+    forkVersion: '00000001',
   },
   {
-    pubkey: '942a9a42b50ce5b36ef017aecbe58b1ae59603415bb5b13145c6f0b58a1b6edde582be879e025e38cf178c15ccbecd4d',
-    withdrawalCredentials: '003b8f16c3af32fa93a03f1ebcbc59ecd0e8050fb38577fcac6f84fc906275d5',
+    pubkey:
+      '942a9a42b50ce5b36ef017aecbe58b1ae59603415bb5b13145c6f0b58a1b6edde582be879e025e38cf178c15ccbecd4d',
+    withdrawalCredentials:
+      '003b8f16c3af32fa93a03f1ebcbc59ecd0e8050fb38577fcac6f84fc906275d5',
     amount: 32000000000,
-    signature: '99064e70c4ff44ddcd495cb102dc52b9ee6da8ac5ed1f1be35ce88b8565d099690d5401b046da0218349e671d0b876e608f805fac9e3b48916e56925548dc2d6666472e3a04c87a08d1d4588201f9c3b9787ce4ee74d65721442650128b0d7e6',
-    depositMessageRoot: '0ec368223e19aebd84e804637022a48bebe6d9a9d3477884ebd72b401cbe6e1c',
-    depositDataRoot: 'cce8f3cc9a795cf413b6eea9bce15ef706b4d75f131f5d35d1feaf2eb6ddf7fb',
-    forkVersion: '00000001'
+    signature:
+      '99064e70c4ff44ddcd495cb102dc52b9ee6da8ac5ed1f1be35ce88b8565d099690d5401b046da0218349e671d0b876e608f805fac9e3b48916e56925548dc2d6666472e3a04c87a08d1d4588201f9c3b9787ce4ee74d65721442650128b0d7e6',
+    depositMessageRoot:
+      '0ec368223e19aebd84e804637022a48bebe6d9a9d3477884ebd72b401cbe6e1c',
+    depositDataRoot:
+      'cce8f3cc9a795cf413b6eea9bce15ef706b4d75f131f5d35d1feaf2eb6ddf7fb',
+    forkVersion: '00000001',
   },
 ];
 
 export const generateBalancesForEpoch = (url: string) => {
-  const params = new URLSearchParams(url.substring(url.indexOf('?'), url.length));
+  const params = new URLSearchParams(
+    url.substring(url.indexOf('?'), url.length)
+  );
   let epoch = '1';
   const paramsEpoch = params.get('epoch');
   if (paramsEpoch) {
@@ -89,6 +115,7 @@ export const generateBalancesForEpoch = (url: string) => {
 };
 
 export const Mocks: IMocks = {
+  '/v2/validator/wallet/recover': {},
   '/v2/validator/login': {
     token: 'mock.jwt.token',
   } as AuthResponse,
@@ -102,7 +129,7 @@ export const Mocks: IMocks = {
   '/v2/validator/wallet': {
     keymanagerConfig: { direct_eip_version: 'EIP-2335' },
     keymanagerKind: 'IMPORTED',
-    walletPath: '/Users/erinlindford/Library/Eth2Validators/prysm-wallet-v2'
+    walletPath: '/Users/erinlindford/Library/Eth2Validators/prysm-wallet-v2',
   } as WalletResponse,
   '/v2/validator/wallet/create': {
     walletPath: '/Users/johndoe/Library/Eth2Validators/prysm-wallet-v2',
@@ -113,7 +140,8 @@ export const Mocks: IMocks = {
   } as ImportKeystoresResponse,
   '/v2/validator/wallet/keystores/validate': {},
   '/v2/validator/mnemonic/generate': {
-    mnemonic: 'grape harvest method public garden knife power era kingdom immense kitchen ethics walk gap thing rude split lazy siren mind vital fork deposit zebra',
+    mnemonic:
+      'grape harvest method public garden knife power era kingdom immense kitchen ethics walk gap thing rude split lazy siren mind vital fork deposit zebra',
   } as GenerateMnemonicResponse,
   '/v2/validator/beacon/status': {
     beaconNodeEndpoint: '127.0.0.1:4000',
@@ -154,199 +182,296 @@ export const Mocks: IMocks = {
     ],
   } as ListAccountsResponse,
   '/v2/validator/beacon/peers': {
-    peers: [{
-        address: '/ip4/66.96.218.122/tcp/13000/p2p/16Uiu2HAmLvc5NkmsMnry6vyZnfLLBpbdsMHLaPeW3aqqavfQXCkx',
+    peers: [
+      {
+        address:
+          '/ip4/66.96.218.122/tcp/13000/p2p/16Uiu2HAmLvc5NkmsMnry6vyZnfLLBpbdsMHLaPeW3aqqavfQXCkx',
         direction: 2,
         connectionState: 2,
         peerId: '16Uiu2HAmLvc5NkmsMnry6vyZnfLLBpbdsMHLaPeW3aqqavfQXCkx',
-        enr: '-LK4QO6sLgvjfBouJt4Lo4J12Rc67ex5g_VBbLGo95VbEqz9RxsqUWaTBx1MwB0lUhAAPsQv2CFWR0tn5tBq2gRD0DMCh2F0dG5ldHOIAEBCIAAAEQCEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhEJg2nqJc2VjcDI1NmsxoQN63ZpGUVRi--fIMVRirw0A1VC_gFdGzvDht1TVb6bHIYN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/83.137.255.115/tcp/13000/p2p/16Uiu2HAmPNwVgsvizCT1wCBWKWqH4N9KLDNPSNdveCaJa9oKuc1s',
+        enr:
+          '-LK4QO6sLgvjfBouJt4Lo4J12Rc67ex5g_VBbLGo95VbEqz9RxsqUWaTBx1MwB0lUhAAPsQv2CFWR0tn5tBq2gRD0DMCh2F0dG5ldHOIAEBCIAAAEQCEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhEJg2nqJc2VjcDI1NmsxoQN63ZpGUVRi--fIMVRirw0A1VC_gFdGzvDht1TVb6bHIYN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/83.137.255.115/tcp/13000/p2p/16Uiu2HAmPNwVgsvizCT1wCBWKWqH4N9KLDNPSNdveCaJa9oKuc1s',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmPNwVgsvizCT1wCBWKWqH4N9KLDNPSNdveCaJa9oKuc1s',
-        enr: '-Ly4QIlofnNMs_Ug7NozFCrU-OMon2Ta6wc7q1YC_0fldE1saMnnr1P9UvDodcB1uRykl2Qzd2xXkf_1IlwC7cGweNqCASCHYXR0bmV0c4jx-eZKww2WyYRldGgykOenXVoAAAAB__________-CaWSCdjSCaXCEU4n_c4lzZWNwMjU2azGhA59UCOyvx8GgBXQG889ox1lFOKlXV3qK0_UxRgmyz2Weg3RjcIIyyIN1ZHCCBICEdWRwNoIu4A=='
-      }, {
-        address: '/ip4/155.93.136.72/tcp/13000/p2p/16Uiu2HAmLp89TTLD4jHA3KfEYuUSZywNEkh39YmxfoME6Z9CL14y',
+        enr:
+          '-Ly4QIlofnNMs_Ug7NozFCrU-OMon2Ta6wc7q1YC_0fldE1saMnnr1P9UvDodcB1uRykl2Qzd2xXkf_1IlwC7cGweNqCASCHYXR0bmV0c4jx-eZKww2WyYRldGgykOenXVoAAAAB__________-CaWSCdjSCaXCEU4n_c4lzZWNwMjU2azGhA59UCOyvx8GgBXQG889ox1lFOKlXV3qK0_UxRgmyz2Weg3RjcIIyyIN1ZHCCBICEdWRwNoIu4A==',
+      },
+      {
+        address:
+          '/ip4/155.93.136.72/tcp/13000/p2p/16Uiu2HAmLp89TTLD4jHA3KfEYuUSZywNEkh39YmxfoME6Z9CL14y',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmLp89TTLD4jHA3KfEYuUSZywNEkh39YmxfoME6Z9CL14y',
-        enr: '-LK4QFQT9Jhm_xvzEbVktYthL7bwjadB7eke12TcCMAexHFcAch-8yVA1HneP5pfBoPXdI3dmg3lfJ2jX1aG22C564Eqh2F0dG5ldHOICBAaAAIRFACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhJtdiEiJc2VjcDI1NmsxoQN5NImiuCvAYY5XWdjHWxZ8hurs9Y1-W2Tmxhg0JliYDoN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/161.97.120.220/tcp/13000/p2p/16Uiu2HAmSTLd1iu2doYUx4rdTkEY54MAsejHhBz83GmKvpd5YtDt',
+        enr:
+          '-LK4QFQT9Jhm_xvzEbVktYthL7bwjadB7eke12TcCMAexHFcAch-8yVA1HneP5pfBoPXdI3dmg3lfJ2jX1aG22C564Eqh2F0dG5ldHOICBAaAAIRFACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhJtdiEiJc2VjcDI1NmsxoQN5NImiuCvAYY5XWdjHWxZ8hurs9Y1-W2Tmxhg0JliYDoN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/161.97.120.220/tcp/13000/p2p/16Uiu2HAmSTLd1iu2doYUx4rdTkEY54MAsejHhBz83GmKvpd5YtDt',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmSTLd1iu2doYUx4rdTkEY54MAsejHhBz83GmKvpd5YtDt',
-        enr: '-LK4QBv1mbTJPk4U18Cr4J2W9vCRo4_QASRxYdeInEloJ47cVP3SHfdNzXXLu2krsQQ4CdQJNK2I6d2wzrfuDVNttr4Ch2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhKFheNyJc2VjcDI1NmsxoQPNB5FfI_ENtWYsAW9gfGXraDgob0s0iLZm8Lqu8-tC74N0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/35.197.3.187/tcp/9001/p2p/16Uiu2HAm9eQrK9YKZRdqGUu6QBeHXb4uvUxq6QRXYr5ioo65kKfr',
+        enr:
+          '-LK4QBv1mbTJPk4U18Cr4J2W9vCRo4_QASRxYdeInEloJ47cVP3SHfdNzXXLu2krsQQ4CdQJNK2I6d2wzrfuDVNttr4Ch2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhKFheNyJc2VjcDI1NmsxoQPNB5FfI_ENtWYsAW9gfGXraDgob0s0iLZm8Lqu8-tC74N0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/35.197.3.187/tcp/9001/p2p/16Uiu2HAm9eQrK9YKZRdqGUu6QBeHXb4uvUxq6QRXYr5ioo65kKfr',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAm9eQrK9YKZRdqGUu6QBeHXb4uvUxq6QRXYr5ioo65kKfr',
-        enr: '-LK4QMg714Poc_OVt_86pi85PfUJdPOVmk_s-gMM3jTS7tJ_K_j8z9ioXy4D4nLGZ-L96bTf5-_mL3a4cUAS_hpGifMCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhCPFA7uJc2VjcDI1NmsxoQLTRw-lNUwbTCXoKq6lF57G4bWeDVbR7oE_KengDnBJ7YN0Y3CCIymDdWRwgiMp'
-      }, {
-        address: '/ip4/135.181.17.59/tcp/11001/p2p/16Uiu2HAmKh3G1PiqKgBMVYT1H1frp885ckUhafWp8xECHWczeV2E',
+        enr:
+          '-LK4QMg714Poc_OVt_86pi85PfUJdPOVmk_s-gMM3jTS7tJ_K_j8z9ioXy4D4nLGZ-L96bTf5-_mL3a4cUAS_hpGifMCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhCPFA7uJc2VjcDI1NmsxoQLTRw-lNUwbTCXoKq6lF57G4bWeDVbR7oE_KengDnBJ7YN0Y3CCIymDdWRwgiMp',
+      },
+      {
+        address:
+          '/ip4/135.181.17.59/tcp/11001/p2p/16Uiu2HAmKh3G1PiqKgBMVYT1H1frp885ckUhafWp8xECHWczeV2E',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmKh3G1PiqKgBMVYT1H1frp885ckUhafWp8xECHWczeV2E',
-        enr: '-LK4QEN3pAp8qPBEkDcc18yPgO_RnKIvZWLZBHLyIhOlMUV4YdxmVBnt-j3-a6Q80agPRwKMoHZE2e581fvN9W1w-wIFh2F0dG5ldHOIAAEAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhIe1ETuJc2VjcDI1NmsxoQNoiEJdQXfB6fbuqzxyvJ1pvyFbqtub6uK4QMLSDcHzr4N0Y3CCKvmDdWRwgir5'
-      }, {
-        address: '/ip4/90.92.55.1/tcp/9000/p2p/16Uiu2HAmS3U6RboxobjhdQMw6ZYJe8ncs1E2UaHHyaXFej8Vk5Cd',
+        enr:
+          '-LK4QEN3pAp8qPBEkDcc18yPgO_RnKIvZWLZBHLyIhOlMUV4YdxmVBnt-j3-a6Q80agPRwKMoHZE2e581fvN9W1w-wIFh2F0dG5ldHOIAAEAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhIe1ETuJc2VjcDI1NmsxoQNoiEJdQXfB6fbuqzxyvJ1pvyFbqtub6uK4QMLSDcHzr4N0Y3CCKvmDdWRwgir5',
+      },
+      {
+        address:
+          '/ip4/90.92.55.1/tcp/9000/p2p/16Uiu2HAmS3U6RboxobjhdQMw6ZYJe8ncs1E2UaHHyaXFej8Vk5Cd',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmS3U6RboxobjhdQMw6ZYJe8ncs1E2UaHHyaXFej8Vk5Cd',
-        enr: '-LK4QD8NBSBmKFrZKNVVpMf8pOccchjmt5P5HFKbsZHuFT9tQBS5KeDOTIKEIlSyk6CcQoI47n9IBHnhq9mdOpDeg4hLh2F0dG5ldHOIAAAAAAAgAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhFpcNwGJc2VjcDI1NmsxoQPG6hPnomqTRZeSFsJPzXpADlk_ZvbWsijHTZe0jrhKCoN0Y3CCIyiDdWRwgiMo'
-      }, {
-        address: '/ip4/51.15.70.7/tcp/9500/p2p/16Uiu2HAmTxXKUd1DFdsudodJostmWRpDVj77e48JKCxUdGm1RLaA',
+        enr:
+          '-LK4QD8NBSBmKFrZKNVVpMf8pOccchjmt5P5HFKbsZHuFT9tQBS5KeDOTIKEIlSyk6CcQoI47n9IBHnhq9mdOpDeg4hLh2F0dG5ldHOIAAAAAAAgAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhFpcNwGJc2VjcDI1NmsxoQPG6hPnomqTRZeSFsJPzXpADlk_ZvbWsijHTZe0jrhKCoN0Y3CCIyiDdWRwgiMo',
+      },
+      {
+        address:
+          '/ip4/51.15.70.7/tcp/9500/p2p/16Uiu2HAmTxXKUd1DFdsudodJostmWRpDVj77e48JKCxUdGm1RLaA',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmTxXKUd1DFdsudodJostmWRpDVj77e48JKCxUdGm1RLaA',
-        enr: '-LO4QAZbEsTmI-sJYObXpNwTFTkMt98GWjh5UQosZH9CSMRrF-L2sBTtJLf_ee0X_6jcMAFAuOFjOZKWHTF6oHBcweOBxYdhdHRuZXRziP__________hGV0aDKQ56ddWgAAAAH__________4JpZIJ2NIJpcIQzD0YHiXNlY3AyNTZrMaED410xsdx5Gghtp3hcSZmk5-XgoG62ty2NbcAnlzxwoS-DdGNwgiUcg3VkcIIjKA=='
-      }, {
-        address: '/ip4/192.241.134.195/tcp/13000/p2p/16Uiu2HAmRdW2tGB5tkbHp6SryR6U2vk8zk7pFUhDjg3AFZp2RJVc',
+        enr:
+          '-LO4QAZbEsTmI-sJYObXpNwTFTkMt98GWjh5UQosZH9CSMRrF-L2sBTtJLf_ee0X_6jcMAFAuOFjOZKWHTF6oHBcweOBxYdhdHRuZXRziP__________hGV0aDKQ56ddWgAAAAH__________4JpZIJ2NIJpcIQzD0YHiXNlY3AyNTZrMaED410xsdx5Gghtp3hcSZmk5-XgoG62ty2NbcAnlzxwoS-DdGNwgiUcg3VkcIIjKA==',
+      },
+      {
+        address:
+          '/ip4/192.241.134.195/tcp/13000/p2p/16Uiu2HAmRdW2tGB5tkbHp6SryR6U2vk8zk7pFUhDjg3AFZp2RJVc',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmRdW2tGB5tkbHp6SryR6U2vk8zk7pFUhDjg3AFZp2RJVc',
-        enr: '-LK4QMA9Mc31oEW0b1qO0EkuZzQbfOBxVGRFi7KcDWY5JdGlTOAb0dPCpcdTy3e-5LbX3MzOX5v0X7SbubSyTsia_vIVh2F0dG5ldHOIAQAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhMDxhsOJc2VjcDI1NmsxoQPAxlSqW_Vx6EM7G56Uc8odv239oG-uCLR-E0_U0k2jD4N0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/207.180.244.247/tcp/13000/p2p/16Uiu2HAkwCy31Sa4CGyr2i48Z6V1cPJ2zswMiS1yKHeCDSwivwzR',
+        enr:
+          '-LK4QMA9Mc31oEW0b1qO0EkuZzQbfOBxVGRFi7KcDWY5JdGlTOAb0dPCpcdTy3e-5LbX3MzOX5v0X7SbubSyTsia_vIVh2F0dG5ldHOIAQAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhMDxhsOJc2VjcDI1NmsxoQPAxlSqW_Vx6EM7G56Uc8odv239oG-uCLR-E0_U0k2jD4N0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/207.180.244.247/tcp/13000/p2p/16Uiu2HAkwCy31Sa4CGyr2i48Z6V1cPJ2zswMiS1yKHeCDSwivwzR',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAkwCy31Sa4CGyr2i48Z6V1cPJ2zswMiS1yKHeCDSwivwzR',
-        enr: '-LK4QAsvRXrk-m0EiXb7t_dXd9xNzxVmhlNR3mA9JBvfan-XWdCWd26nzaZyUmfjXh0t338j7M41YknDrxR7JCr6tK1qh2F0dG5ldHOI3vdI7n_f_3-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhM-09PeJc2VjcDI1NmsxoQIadhuj7lfhkM8sChMNbSY0Auuu85qd-BOt63wZBB87coN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/142.93.180.80/tcp/13000/p2p/16Uiu2HAm889yCc1ShrApZyM2qCfhtH9ufqWoTEvcfTowVA9HRhtw',
+        enr:
+          '-LK4QAsvRXrk-m0EiXb7t_dXd9xNzxVmhlNR3mA9JBvfan-XWdCWd26nzaZyUmfjXh0t338j7M41YknDrxR7JCr6tK1qh2F0dG5ldHOI3vdI7n_f_3-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhM-09PeJc2VjcDI1NmsxoQIadhuj7lfhkM8sChMNbSY0Auuu85qd-BOt63wZBB87coN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/142.93.180.80/tcp/13000/p2p/16Uiu2HAm889yCc1ShrApZyM2qCfhtH9ufqWoTEvcfTowVA9HRhtw',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAm889yCc1ShrApZyM2qCfhtH9ufqWoTEvcfTowVA9HRhtw',
-        enr: '-LO4QGNMdAziIg8AnQdrwIXY3Tan2bdy5ipd03vLMZwEO0ddRGpXlSLD_lMk1tsHpamqk-gtta0bhd6a7t8avLf2uCqB7YdhdHRuZXRziAACFAFADRQAhGV0aDKQ56ddWgAAAAH__________4JpZIJ2NIJpcISOXbRQiXNlY3AyNTZrMaECvKsfpgBmhqKMypSVgKLZODBvbika9Wy1unvGO1fWE2SDdGNwgjLIg3VkcIIu4A=='
-      }, {
-        address: '/ip4/95.217.218.193/tcp/13000/p2p/16Uiu2HAmBZJYzwfo9j2zCu3e2mu39KQf5WmxGB8psAyEXAtpZdFF',
+        enr:
+          '-LO4QGNMdAziIg8AnQdrwIXY3Tan2bdy5ipd03vLMZwEO0ddRGpXlSLD_lMk1tsHpamqk-gtta0bhd6a7t8avLf2uCqB7YdhdHRuZXRziAACFAFADRQAhGV0aDKQ56ddWgAAAAH__________4JpZIJ2NIJpcISOXbRQiXNlY3AyNTZrMaECvKsfpgBmhqKMypSVgKLZODBvbika9Wy1unvGO1fWE2SDdGNwgjLIg3VkcIIu4A==',
+      },
+      {
+        address:
+          '/ip4/95.217.218.193/tcp/13000/p2p/16Uiu2HAmBZJYzwfo9j2zCu3e2mu39KQf5WmxGB8psAyEXAtpZdFF',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmBZJYzwfo9j2zCu3e2mu39KQf5WmxGB8psAyEXAtpZdFF',
-        enr: '-LK4QNrCgSB9K0t9sREtgEvrMPIlp_1NCJGWiiJnsTUxDUL0c_c5ZCZH8RNfpCbPZm1usonPPqUvBZBNTJ3fz710NwYCh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhF_Z2sGJc2VjcDI1NmsxoQLvr2i_QG_mcuu9Z4LgrWbamcwIXWXisooICrozlJmqWoN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/46.236.194.36/tcp/13000/p2p/16Uiu2HAm8R1ue5VF6QYRBtzBJT5rmg2KRSRuQeFyKSN2etj4SAQR',
+        enr:
+          '-LK4QNrCgSB9K0t9sREtgEvrMPIlp_1NCJGWiiJnsTUxDUL0c_c5ZCZH8RNfpCbPZm1usonPPqUvBZBNTJ3fz710NwYCh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhF_Z2sGJc2VjcDI1NmsxoQLvr2i_QG_mcuu9Z4LgrWbamcwIXWXisooICrozlJmqWoN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/46.236.194.36/tcp/13000/p2p/16Uiu2HAm8R1ue5VF6QYRBtzBJT5rmg2KRSRuQeFyKSN2etj4SAQR',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAm8R1ue5VF6QYRBtzBJT5rmg2KRSRuQeFyKSN2etj4SAQR',
-        enr: '-LK4QBZBkFdArf_m7F4L7eSHe7qV46S4iIZAhBBP64JD9g62MEzNGKeUSWqme9KvEho9SAwuk6f2LBtQdKLphPOmWooMh2F0dG5ldHOIAIAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhC7swiSJc2VjcDI1NmsxoQLA_OHgsf7wo3g0cjvjgt2tXaPbzTtiX2dIiC0RHeF3KoN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/68.97.20.181/tcp/13000/p2p/16Uiu2HAmCBvxmZXpv1oU9NTNabKfQk9dF69E3GD29n4ETVLzVghD',
+        enr:
+          '-LK4QBZBkFdArf_m7F4L7eSHe7qV46S4iIZAhBBP64JD9g62MEzNGKeUSWqme9KvEho9SAwuk6f2LBtQdKLphPOmWooMh2F0dG5ldHOIAIAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhC7swiSJc2VjcDI1NmsxoQLA_OHgsf7wo3g0cjvjgt2tXaPbzTtiX2dIiC0RHeF3KoN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/68.97.20.181/tcp/13000/p2p/16Uiu2HAmCBvxmZXpv1oU9NTNabKfQk9dF69E3GD29n4ETVLzVghD',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmCBvxmZXpv1oU9NTNabKfQk9dF69E3GD29n4ETVLzVghD',
-        enr: '-LK4QMogcECI8mZLSv4V3aYYGhRJMsI-qyYrnFaUu2sLeEHiZrAhrJcNeEMZnh2RaM2ZCGmDDk4K70LDoeyCEeMCBUABh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhERhFLWJc2VjcDI1NmsxoQL5EXysT6_721xB9HGL0KDD805OfGrBMt6S164pc4loaIN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/81.61.61.174/tcp/13000/p2p/16Uiu2HAmQm5wEXrnSxRLDkCx7BhRbBehpJ6nnkb9tmJQyYoVNn3u',
+        enr:
+          '-LK4QMogcECI8mZLSv4V3aYYGhRJMsI-qyYrnFaUu2sLeEHiZrAhrJcNeEMZnh2RaM2ZCGmDDk4K70LDoeyCEeMCBUABh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhERhFLWJc2VjcDI1NmsxoQL5EXysT6_721xB9HGL0KDD805OfGrBMt6S164pc4loaIN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/81.61.61.174/tcp/13000/p2p/16Uiu2HAmQm5wEXrnSxRLDkCx7BhRbBehpJ6nnkb9tmJQyYoVNn3u',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmQm5wEXrnSxRLDkCx7BhRbBehpJ6nnkb9tmJQyYoVNn3u',
-        enr: '-LK4QMurhtUl2O_DYyQGNBOMe35SYA258cHvFb_CkuJASviIY3buH2hbbqYK9zBo7YnkZXHh5YxMMWlznFZ86hUzIggCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhFE9Pa6Jc2VjcDI1NmsxoQOz3AsQ_9p7sIMyFeRrkmjCQJAE-5eqSVt8whrZpSkMhIN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/71.244.103.3/tcp/13000/p2p/16Uiu2HAmJogALY3TCFffYWZxKT4SykEGMAPzdVvfrr149N1fwoFY',
+        enr:
+          '-LK4QMurhtUl2O_DYyQGNBOMe35SYA258cHvFb_CkuJASviIY3buH2hbbqYK9zBo7YnkZXHh5YxMMWlznFZ86hUzIggCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhFE9Pa6Jc2VjcDI1NmsxoQOz3AsQ_9p7sIMyFeRrkmjCQJAE-5eqSVt8whrZpSkMhIN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/71.244.103.3/tcp/13000/p2p/16Uiu2HAmJogALY3TCFffYWZxKT4SykEGMAPzdVvfrr149N1fwoFY',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmJogALY3TCFffYWZxKT4SykEGMAPzdVvfrr149N1fwoFY',
-        enr: '-LK4QKekP-beWUJwlRWlw5NMggQl2bIesoUYfr50aGdpIISzEGzTMDvWOyegAFFIopKlICuqxBvcj1Fxc09k6ZDu3mgKh2F0dG5ldHOIAAAAAAAIAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhEf0ZwOJc2VjcDI1NmsxoQNbX8hcitIiNVYKmJTT9FpaRUKhPveqAR3peDAJV7S604N0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/193.81.37.89/tcp/9001/p2p/16Uiu2HAkyCfL1KHRf1yMHpASMZb5GcWX9S5AryWMKxz9ybQJBuJ7',
+        enr:
+          '-LK4QKekP-beWUJwlRWlw5NMggQl2bIesoUYfr50aGdpIISzEGzTMDvWOyegAFFIopKlICuqxBvcj1Fxc09k6ZDu3mgKh2F0dG5ldHOIAAAAAAAIAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhEf0ZwOJc2VjcDI1NmsxoQNbX8hcitIiNVYKmJTT9FpaRUKhPveqAR3peDAJV7S604N0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/193.81.37.89/tcp/9001/p2p/16Uiu2HAkyCfL1KHRf1yMHpASMZb5GcWX9S5AryWMKxz9ybQJBuJ7',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAkyCfL1KHRf1yMHpASMZb5GcWX9S5AryWMKxz9ybQJBuJ7',
-        enr: '-LK4QLgSaeoEns2jri5S_aryVPxbHzWUK6T57DyP5xalEu2KQ1zn_kihUG8ncc7D97OxIxNthZG5s5KtTBXQePLsmtISh2F0dG5ldHOICAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhMFRJVmJc2VjcDI1NmsxoQI4GXXlOBhnkTCCN7f3JYqSQFEtimux0m2VcQZFFDdCsIN0Y3CCIymDdWRwgiMp'
-      }, {
-        address: '/ip4/203.123.127.154/tcp/13000/p2p/16Uiu2HAmSTqQx7nW6fBQvdHYdaCj2VF4bvh8ttZzdUyvLEFKJh3y',
+        enr:
+          '-LK4QLgSaeoEns2jri5S_aryVPxbHzWUK6T57DyP5xalEu2KQ1zn_kihUG8ncc7D97OxIxNthZG5s5KtTBXQePLsmtISh2F0dG5ldHOICAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhMFRJVmJc2VjcDI1NmsxoQI4GXXlOBhnkTCCN7f3JYqSQFEtimux0m2VcQZFFDdCsIN0Y3CCIymDdWRwgiMp',
+      },
+      {
+        address:
+          '/ip4/203.123.127.154/tcp/13000/p2p/16Uiu2HAmSTqQx7nW6fBQvdHYdaCj2VF4bvh8ttZzdUyvLEFKJh3y',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmSTqQx7nW6fBQvdHYdaCj2VF4bvh8ttZzdUyvLEFKJh3y',
-        enr: '-LK4QOB0EcZQ7oi49pWb9irDXlwKJztl5pdl8Ni1k-njoik_To638d7FRpqlewGJ8-rYcv4onNSm2cttbaFPqRh1f4IBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhMt7f5qJc2VjcDI1NmsxoQPNKB-ERJoaTH7ZQUylPZtCXe__NaNKVNYTfJvCo-gelIN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/95.217.122.169/tcp/11001/p2p/16Uiu2HAmQFM2VS2vAJrcVkKZbDtHwTauhXmuHLXsX25ECmqCpL15',
+        enr:
+          '-LK4QOB0EcZQ7oi49pWb9irDXlwKJztl5pdl8Ni1k-njoik_To638d7FRpqlewGJ8-rYcv4onNSm2cttbaFPqRh1f4IBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhMt7f5qJc2VjcDI1NmsxoQPNKB-ERJoaTH7ZQUylPZtCXe__NaNKVNYTfJvCo-gelIN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/95.217.122.169/tcp/11001/p2p/16Uiu2HAmQFM2VS2vAJrcVkKZbDtHwTauhXmuHLXsX25ECmqCpL15',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmQFM2VS2vAJrcVkKZbDtHwTauhXmuHLXsX25ECmqCpL15',
-        enr: '-LK4QK_SNVm85T1olSVPKlJ7k3ExB38YWDEZiQmCl8wj-eGWHStMd5wHUG9bi6qjtrFDiZoxVmCOIBqNrftl1iE1Dr4Hh2F0dG5ldHOIQAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhF_ZeqmJc2VjcDI1NmsxoQOsPa6XDlpLGmIMr8ESuTGALvEAGLp2YwGUqDoyXvNUOIN0Y3CCKvmDdWRwgir5'
-      }, {
-        address: '/ip4/74.199.47.20/tcp/13100/p2p/16Uiu2HAkv1QpH7uDM5WMtiJUZUqQzHVmWSqTg68W94AVd31VEEZu',
+        enr:
+          '-LK4QK_SNVm85T1olSVPKlJ7k3ExB38YWDEZiQmCl8wj-eGWHStMd5wHUG9bi6qjtrFDiZoxVmCOIBqNrftl1iE1Dr4Hh2F0dG5ldHOIQAAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhF_ZeqmJc2VjcDI1NmsxoQOsPa6XDlpLGmIMr8ESuTGALvEAGLp2YwGUqDoyXvNUOIN0Y3CCKvmDdWRwgir5',
+      },
+      {
+        address:
+          '/ip4/74.199.47.20/tcp/13100/p2p/16Uiu2HAkv1QpH7uDM5WMtiJUZUqQzHVmWSqTg68W94AVd31VEEZu',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAkv1QpH7uDM5WMtiJUZUqQzHVmWSqTg68W94AVd31VEEZu',
-        enr: '-LK4QDumfVEd0uDO61jWNXZrCiAQ06aqGDDvwOKTIE9Yq3zNXDJN_yRV2xgUu37GeKOx_mZSZT_NE13Yxb0FesueFp90h2F0dG5ldHOIAAAAABAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhErHLxSJc2VjcDI1NmsxoQIIpJn5mAXbQ8g6VlEwa61lyWkHduP8Vf1EU1X-BFeckIN0Y3CCMyyDdWRwgi9E'
-      }, {
-        address: '/ip4/24.107.187.198/tcp/9000/p2p/16Uiu2HAm4FYUgC1PahBVwYUppJV5zSPhFeMxKYwQEnjoSpJNNqw4',
+        enr:
+          '-LK4QDumfVEd0uDO61jWNXZrCiAQ06aqGDDvwOKTIE9Yq3zNXDJN_yRV2xgUu37GeKOx_mZSZT_NE13Yxb0FesueFp90h2F0dG5ldHOIAAAAABAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhErHLxSJc2VjcDI1NmsxoQIIpJn5mAXbQ8g6VlEwa61lyWkHduP8Vf1EU1X-BFeckIN0Y3CCMyyDdWRwgi9E',
+      },
+      {
+        address:
+          '/ip4/24.107.187.198/tcp/9000/p2p/16Uiu2HAm4FYUgC1PahBVwYUppJV5zSPhFeMxKYwQEnjoSpJNNqw4',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAm4FYUgC1PahBVwYUppJV5zSPhFeMxKYwQEnjoSpJNNqw4',
-        enr: '-LK4QI6UW8aGDMmArQ30O0I_jZEi88kYGBS0_JKauNl6Kz-EFSowowzxRTMJeznWHVqLvw0wQCa3UY-HeQrKT-HpG_UBh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhBhru8aJc2VjcDI1NmsxoQKDIORFrWiUTct3NdUnjsQ2c9tXIxpopEDzMuwABQ00d4N0Y3CCIyiDdWRwgiMo'
-      }, {
-        address: '/ip4/95.111.254.160/tcp/13000/p2p/16Uiu2HAmQhEoww9P8sPve2fs9deYro6EDctYzS5hQD57zSDS7nvz',
+        enr:
+          '-LK4QI6UW8aGDMmArQ30O0I_jZEi88kYGBS0_JKauNl6Kz-EFSowowzxRTMJeznWHVqLvw0wQCa3UY-HeQrKT-HpG_UBh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhBhru8aJc2VjcDI1NmsxoQKDIORFrWiUTct3NdUnjsQ2c9tXIxpopEDzMuwABQ00d4N0Y3CCIyiDdWRwgiMo',
+      },
+      {
+        address:
+          '/ip4/95.111.254.160/tcp/13000/p2p/16Uiu2HAmQhEoww9P8sPve2fs9deYro6EDctYzS5hQD57zSDS7nvz',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmQhEoww9P8sPve2fs9deYro6EDctYzS5hQD57zSDS7nvz',
-        enr: '-LK4QFJ9IN2HyrqXZxKpkWD3f9j8vJVPdyPkBMFEJCSHiKTYRAMPL2U524IIlY0lBJPW8ouzcp-ziKLLhgNagmezwyQRh2F0dG5ldHOIAAAAAAACAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhF9v_qCJc2VjcDI1NmsxoQOy38EYjvf7AfNp5JJScFtmAa4QEOlV4p6ymzYRpnILT4N0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/216.243.55.81/tcp/19000/p2p/16Uiu2HAkud68NRLuAoTsXVQGXntm5zBFiVov9qUXRJ5SjvQjKX9v',
+        enr:
+          '-LK4QFJ9IN2HyrqXZxKpkWD3f9j8vJVPdyPkBMFEJCSHiKTYRAMPL2U524IIlY0lBJPW8ouzcp-ziKLLhgNagmezwyQRh2F0dG5ldHOIAAAAAAACAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhF9v_qCJc2VjcDI1NmsxoQOy38EYjvf7AfNp5JJScFtmAa4QEOlV4p6ymzYRpnILT4N0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/216.243.55.81/tcp/19000/p2p/16Uiu2HAkud68NRLuAoTsXVQGXntm5zBFiVov9qUXRJ5SjvQjKX9v',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAkud68NRLuAoTsXVQGXntm5zBFiVov9qUXRJ5SjvQjKX9v',
-        enr: '-LK4QFtd9lcRMGn9GyRkjP_1EO1gvv8l1LhqBv6GrXjf5IqQXITkgiFepEMBB7Ph13z_1SbwUOupz1kRlaPYRgfOTyQBh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhNjzN1GJc2VjcDI1NmsxoQIC7LFnjN_YSu9jPsbYVL7tLC4b2m-UQ0j148vallFCTYN0Y3CCSjiDdWRwgko4'
-      }, {
-        address: '/ip4/24.52.248.93/tcp/32900/p2p/16Uiu2HAmGDsgjpjDUBx7Xp6MnCBqsD2N7EHtK3QusWTf6pZFJvUj',
+        enr:
+          '-LK4QFtd9lcRMGn9GyRkjP_1EO1gvv8l1LhqBv6GrXjf5IqQXITkgiFepEMBB7Ph13z_1SbwUOupz1kRlaPYRgfOTyQBh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhNjzN1GJc2VjcDI1NmsxoQIC7LFnjN_YSu9jPsbYVL7tLC4b2m-UQ0j148vallFCTYN0Y3CCSjiDdWRwgko4',
+      },
+      {
+        address:
+          '/ip4/24.52.248.93/tcp/32900/p2p/16Uiu2HAmGDsgjpjDUBx7Xp6MnCBqsD2N7EHtK3QusWTf6pZFJvUj',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmGDsgjpjDUBx7Xp6MnCBqsD2N7EHtK3QusWTf6pZFJvUj',
-        enr: '-LK4QH3e9vgnWtvf_z_Fi_g3BiBxySGFyGDVfL-2l8vh9HyhfNDIHqzoiUfK2hbYAlGwIjSgGlTzvRXxrZJtJKhxYE4Bh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhBg0-F2Jc2VjcDI1NmsxoQM0_7EUNTto4R_9ZWiD4N0XDN6hyWr-F7hiWKoHc-auhIN0Y3CCgISDdWRwgoCE'
-      }, {
-        address: '/ip4/78.34.189.199/tcp/13000/p2p/16Uiu2HAm8rBxfRE8bZauEJhfUMMCtmuGsJ7X9sRtFQ2WPKvX2g8a',
+        enr:
+          '-LK4QH3e9vgnWtvf_z_Fi_g3BiBxySGFyGDVfL-2l8vh9HyhfNDIHqzoiUfK2hbYAlGwIjSgGlTzvRXxrZJtJKhxYE4Bh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhBg0-F2Jc2VjcDI1NmsxoQM0_7EUNTto4R_9ZWiD4N0XDN6hyWr-F7hiWKoHc-auhIN0Y3CCgISDdWRwgoCE',
+      },
+      {
+        address:
+          '/ip4/78.34.189.199/tcp/13000/p2p/16Uiu2HAm8rBxfRE8bZauEJhfUMMCtmuGsJ7X9sRtFQ2WPKvX2g8a',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAm8rBxfRE8bZauEJhfUMMCtmuGsJ7X9sRtFQ2WPKvX2g8a',
-        enr: '-LK4QEXRE9ObQZxUISYko3tF61sKFwall6RtYtogR6Do_CN0bLmFRVDAzt83eeU_xQEhpEhonRGKmm4IT5L6rBj4DCcDh2F0dG5ldHOIhROMB0ExA0KEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhE4ivceJc2VjcDI1NmsxoQLHb8S-kwOy5rSXNj6yTmUI8YEMtT8F5HxA_BG_Q98I24N0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/35.246.89.6/tcp/9001/p2p/16Uiu2HAmScpoS3ycGQt71n4Untszc8JFvzcSSxhx89s6wNSfZW9i',
+        enr:
+          '-LK4QEXRE9ObQZxUISYko3tF61sKFwall6RtYtogR6Do_CN0bLmFRVDAzt83eeU_xQEhpEhonRGKmm4IT5L6rBj4DCcDh2F0dG5ldHOIhROMB0ExA0KEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhE4ivceJc2VjcDI1NmsxoQLHb8S-kwOy5rSXNj6yTmUI8YEMtT8F5HxA_BG_Q98I24N0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/35.246.89.6/tcp/9001/p2p/16Uiu2HAmScpoS3ycGQt71n4Untszc8JFvzcSSxhx89s6wNSfZW9i',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmScpoS3ycGQt71n4Untszc8JFvzcSSxhx89s6wNSfZW9i',
-        enr: '-LK4QEF2wrLiztk1x541oH-meS_2nVntC6_pjvvGSneo3lCjAQt6DI1IZHOEED3eSipNsxsbCVTOdnqAlGSfUd3dvvIRh2F0dG5ldHOIAAABAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhCP2WQaJc2VjcDI1NmsxoQPPdahwhMnKaznrBkOX4lozrwYiEHhGWxr0vAD8x-qsTYN0Y3CCIymDdWRwgiMp'
-      }, {
-        address: '/ip4/46.166.92.26/tcp/13000/p2p/16Uiu2HAmKebyopoHAAPJQBuRBNZoLzG9xBcVFppS4vZLpZFBhpeF',
+        enr:
+          '-LK4QEF2wrLiztk1x541oH-meS_2nVntC6_pjvvGSneo3lCjAQt6DI1IZHOEED3eSipNsxsbCVTOdnqAlGSfUd3dvvIRh2F0dG5ldHOIAAABAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhCP2WQaJc2VjcDI1NmsxoQPPdahwhMnKaznrBkOX4lozrwYiEHhGWxr0vAD8x-qsTYN0Y3CCIymDdWRwgiMp',
+      },
+      {
+        address:
+          '/ip4/46.166.92.26/tcp/13000/p2p/16Uiu2HAmKebyopoHAAPJQBuRBNZoLzG9xBcVFppS4vZLpZFBhpeF',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmKebyopoHAAPJQBuRBNZoLzG9xBcVFppS4vZLpZFBhpeF',
-        enr: '-LK4QFw7THHqZTOyAB5NaiMAIHj3Z06FfvfqChAI9xbTTG16KvfEURz1aHB6MqTvY946YLv7lZFEFRjd6iRBOHG3GV8Ih2F0dG5ldHOIAgAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhC6mXBqJc2VjcDI1NmsxoQNn6IOj-nv3TQ8P1Ks6nkIw9aOrkpwMHADplWFqlLyeLIN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/98.110.221.150/tcp/13000/p2p/16Uiu2HAm4qPpetSWpzSWt93bg7hSuf7Hob343CQHxCiUowBF8ZEy',
+        enr:
+          '-LK4QFw7THHqZTOyAB5NaiMAIHj3Z06FfvfqChAI9xbTTG16KvfEURz1aHB6MqTvY946YLv7lZFEFRjd6iRBOHG3GV8Ih2F0dG5ldHOIAgAAAAAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhC6mXBqJc2VjcDI1NmsxoQNn6IOj-nv3TQ8P1Ks6nkIw9aOrkpwMHADplWFqlLyeLIN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/98.110.221.150/tcp/13000/p2p/16Uiu2HAm4qPpetSWpzSWt93bg7hSuf7Hob343CQHxCiUowBF8ZEy',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAm4qPpetSWpzSWt93bg7hSuf7Hob343CQHxCiUowBF8ZEy',
-        enr: '-LK4QCoWL-QoEVUsF8EKmFeLR5zabehH1OF52z7ST9SbyiU7K-nwGzXA7Hseno9UeOulMlBef19s_ucxVNQElbpqAdssh2F0dG5ldHOIAAAAACAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhGJu3ZaJc2VjcDI1NmsxoQKLzNox6sgMe65lv5Pt_-LQMeI7FO90lEY3BPTtyDYLYoN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/104.251.255.120/tcp/13000/p2p/16Uiu2HAkvPCeuXUjFq3bwHoxc8MSjypWdkiPnSb4KyxsUu4GNmEn',
+        enr:
+          '-LK4QCoWL-QoEVUsF8EKmFeLR5zabehH1OF52z7ST9SbyiU7K-nwGzXA7Hseno9UeOulMlBef19s_ucxVNQElbpqAdssh2F0dG5ldHOIAAAAACAAAACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhGJu3ZaJc2VjcDI1NmsxoQKLzNox6sgMe65lv5Pt_-LQMeI7FO90lEY3BPTtyDYLYoN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/104.251.255.120/tcp/13000/p2p/16Uiu2HAkvPCeuXUjFq3bwHoxc8MSjypWdkiPnSb4KyxsUu4GNmEn',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAkvPCeuXUjFq3bwHoxc8MSjypWdkiPnSb4KyxsUu4GNmEn',
-        enr: '-LK4QDGY2BvvP_7TvqJFXOZ1nMw9xGsvidF5Ekaevayi11k8B7hKLQvbyyOsun1-5pPsrtn6VEzIaXXyZdtV2szQsgIIh2F0dG5ldHOIAAAAAAAAAECEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhGj7_3iJc2VjcDI1NmsxoQIOOaDLwwyS2D3LSXcSoWpDfc51EmDl3Uo_iLZryBHX54N0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/116.203.252.60/tcp/13000/p2p/16Uiu2HAm6Jm9N8CoydFzjAtbxx5vaQrdkD1knZv6h9xkNRUrC9Hf',
+        enr:
+          '-LK4QDGY2BvvP_7TvqJFXOZ1nMw9xGsvidF5Ekaevayi11k8B7hKLQvbyyOsun1-5pPsrtn6VEzIaXXyZdtV2szQsgIIh2F0dG5ldHOIAAAAAAAAAECEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhGj7_3iJc2VjcDI1NmsxoQIOOaDLwwyS2D3LSXcSoWpDfc51EmDl3Uo_iLZryBHX54N0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/116.203.252.60/tcp/13000/p2p/16Uiu2HAm6Jm9N8CoydFzjAtbxx5vaQrdkD1knZv6h9xkNRUrC9Hf',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAm6Jm9N8CoydFzjAtbxx5vaQrdkD1knZv6h9xkNRUrC9Hf',
-        enr: '-LK4QBeW2sMQ0y77ONJd-dfZOWKiu0DcacavmY05sLeKZnGALsM5ViteToq4KobaaOEXcMeMjaNHh3Jkleohhh-3SZQCh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhHTL_DyJc2VjcDI1NmsxoQKhq1Sk0QqCyzZPPYyta-SJu79W5dQkS23sH06YRlYYDoN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/24.4.149.245/tcp/13000/p2p/16Uiu2HAmQ29MmPnnGENBG952xrqtRsUGdm1MJWQsKN3nsvNhBr6c',
+        enr:
+          '-LK4QBeW2sMQ0y77ONJd-dfZOWKiu0DcacavmY05sLeKZnGALsM5ViteToq4KobaaOEXcMeMjaNHh3Jkleohhh-3SZQCh2F0dG5ldHOI__________-EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhHTL_DyJc2VjcDI1NmsxoQKhq1Sk0QqCyzZPPYyta-SJu79W5dQkS23sH06YRlYYDoN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/24.4.149.245/tcp/13000/p2p/16Uiu2HAmQ29MmPnnGENBG952xrqtRsUGdm1MJWQsKN3nsvNhBr6c',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmQ29MmPnnGENBG952xrqtRsUGdm1MJWQsKN3nsvNhBr6c',
-        enr: '-LK4QD2iKDsZm1nANdp3CtP4bkgrqe6y0_wtaQdWuwc-TYiETgVVrJ0nVq31SwfGJojACnRSNZmsPxrVWwIGCCzqmbwCh2F0dG5ldHOIcQig9EthDJ2EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhBgElfWJc2VjcDI1NmsxoQOo2_BVIae-SNx5t_Z-_UXPTJWcYe9y31DK5iML-2i4mYN0Y3CCMsiDdWRwgi7g'
-      }, {
-        address: '/ip4/104.225.218.208/tcp/13000/p2p/16Uiu2HAmFkHJbiGwJHafuYMNMbuQiL4GiXfhp9ozJw7KwPg6a54A',
+        enr:
+          '-LK4QD2iKDsZm1nANdp3CtP4bkgrqe6y0_wtaQdWuwc-TYiETgVVrJ0nVq31SwfGJojACnRSNZmsPxrVWwIGCCzqmbwCh2F0dG5ldHOIcQig9EthDJ2EZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhBgElfWJc2VjcDI1NmsxoQOo2_BVIae-SNx5t_Z-_UXPTJWcYe9y31DK5iML-2i4mYN0Y3CCMsiDdWRwgi7g',
+      },
+      {
+        address:
+          '/ip4/104.225.218.208/tcp/13000/p2p/16Uiu2HAmFkHJbiGwJHafuYMNMbuQiL4GiXfhp9ozJw7KwPg6a54A',
         direction: 'OUTBOUND',
         connectionState: 2,
         peerId: '16Uiu2HAmFkHJbiGwJHafuYMNMbuQiL4GiXfhp9ozJw7KwPg6a54A',
-        enr: '-LK4QMxEUMfj7wwQIXxknbEw29HVM1ABKlCNo5EgMzOL0x-5BObVBPX1viI2T0fJrm5vkzfIFGkucoa9ghdndKxXG61yh2F0dG5ldHOIIAQAAAAAgACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhGjh2tCJc2VjcDI1NmsxoQMt7iJjp0U3rszrj4rPW7tUQ864MJ0CyCNTuHAYN7N_n4N0Y3CCMsiDdWRwgi7g'
-      }]
+        enr:
+          '-LK4QMxEUMfj7wwQIXxknbEw29HVM1ABKlCNo5EgMzOL0x-5BObVBPX1viI2T0fJrm5vkzfIFGkucoa9ghdndKxXG61yh2F0dG5ldHOIIAQAAAAAgACEZXRoMpDnp11aAAAAAf__________gmlkgnY0gmlwhGjh2tCJc2VjcDI1NmsxoQMt7iJjp0U3rszrj4rPW7tUQ864MJ0CyCNTuHAYN7N_n4N0Y3CCMsiDdWRwgi7g',
+      },
+    ],
   } as Peers,
   '/v2/validator/beacon/participation': {
     epoch: 32,
@@ -372,21 +497,20 @@ export const Mocks: IMocks = {
     averageActiveValidatorBalance: '31000000000',
     inclusionDistances: ['2', '2', '1'],
     inclusionSlots: ['3022', '1022', '1021'],
-    balancesBeforeEpochTransition: ['31200781367', '31216554607', '31204371127'],
+    balancesBeforeEpochTransition: [
+      '31200781367',
+      '31216554607',
+      '31204371127',
+    ],
     balancesAfterEpochTransition: ['31200823019', '31216596259', '31204412779'],
     publicKeys: mockPublicKeys,
     missingValidators: [],
   } as ValidatorPerformanceResponse,
   '/v2/validator/beacon/queue': {
     churnLimit: 4,
-    activationPublicKeys: [
-      mockPublicKeys[0],
-      mockPublicKeys[1],
-    ],
+    activationPublicKeys: [mockPublicKeys[0], mockPublicKeys[1]],
     activationValidatorIndices: [0, 1],
-    exitPublicKeys: [
-      mockPublicKeys[2],
-    ],
+    exitPublicKeys: [mockPublicKeys[2]],
     exitValidatorIndices: [2],
   } as ValidatorQueue,
   '/v2/validator/beacon/validators': {

--- a/src/app/modules/core/services/wallet.service.ts
+++ b/src/app/modules/core/services/wallet.service.ts
@@ -97,7 +97,8 @@ export class WalletService {
   recover(request: RecoverWalletRequest): Observable<any> {
     return this.http.post(`${this.apiUrl}/wallet/recover`, request);
   }
-  exitAccounts(request: AccountVoluntaryExitRequest) {
+
+  exitAccounts(request: AccountVoluntaryExitRequest): Observable<any> {
     return this.http.post(`${this.apiUrl}/wallet/exit-accoints`, request);
   }
 }

--- a/src/app/modules/core/services/wallet.service.ts
+++ b/src/app/modules/core/services/wallet.service.ts
@@ -3,7 +3,10 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { map, share, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { EnvironmenterService } from './environmenter.service';
-import { RecoverWalletRequest } from '../../../proto/validator/accounts/v2/web_api';
+import {
+  RecoverWalletRequest,
+  AccountVoluntaryExitRequest,
+} from '../../../proto/validator/accounts/v2/web_api';
 import {
   WalletResponse,
   GenerateMnemonicResponse,
@@ -17,39 +20,45 @@ import {
 } from 'src/app/proto/validator/accounts/v2/web_api';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class WalletService {
   constructor(
     private http: HttpClient,
-    private environmenter: EnvironmenterService,
-  ) { }
+    private environmenter: EnvironmenterService
+  ) {}
 
   private apiUrl = this.environmenter.env.validatorEndpoint;
 
   // Observables.
-  walletConfig$: Observable<WalletResponse> = this.http.get<WalletResponse>(`${this.apiUrl}/wallet`).pipe(
-    share(),
-  );
-  validatingPublicKeys$: Observable<string[]> = this.http.get<ListAccountsResponse>(
-    `${this.apiUrl}/accounts?all=true`
-  ).pipe(
-    map((res: ListAccountsResponse) => res.accounts.map((acc: Account) => acc.validatingPublicKey)),
-    share(),
-  );
+  walletConfig$: Observable<WalletResponse> = this.http
+    .get<WalletResponse>(`${this.apiUrl}/wallet`)
+    .pipe(share());
+  validatingPublicKeys$: Observable<
+    string[]
+  > = this.http
+    .get<ListAccountsResponse>(`${this.apiUrl}/accounts?all=true`)
+    .pipe(
+      map((res: ListAccountsResponse) =>
+        res.accounts.map((acc: Account) => acc.validatingPublicKey)
+      ),
+      share()
+    );
 
   // Retrieve a randomly generateed bip39 mnemonic from the backend,
   // ensuring it can be replayed by multiple subscribers. For example: being able
   // to verify the generated mnemonic matches the user input in a confirmation box
   // would require share replay for us to compare to the proper value.
-  generateMnemonic$ = this.http.get<GenerateMnemonicResponse>(`${this.apiUrl}/mnemonic/generate`).pipe(
-    map((resp: GenerateMnemonicResponse) => resp.mnemonic),
-    shareReplay(1),
-  );
+  generateMnemonic$ = this.http
+    .get<GenerateMnemonicResponse>(`${this.apiUrl}/mnemonic/generate`)
+    .pipe(
+      map((resp: GenerateMnemonicResponse) => resp.mnemonic),
+      shareReplay(1)
+    );
 
   accounts(
     pageIndex?: number,
-    pageSize?: number,
+    pageSize?: number
   ): Observable<ListAccountsResponse> {
     let params = `?`;
     if (pageIndex) {
@@ -58,23 +67,37 @@ export class WalletService {
     if (pageSize) {
       params += `pageSize=${pageSize}`;
     }
-    return this.http.get<ListAccountsResponse>(`${this.apiUrl}/accounts${params}`).pipe(
-      share(),
-    );
+    return this.http
+      .get<ListAccountsResponse>(`${this.apiUrl}/accounts${params}`)
+      .pipe(share());
   }
 
   createWallet(request: CreateWalletRequest): Observable<CreateWalletResponse> {
-    return this.http.post<CreateWalletResponse>(`${this.apiUrl}/wallet/create`, request);
+    return this.http.post<CreateWalletResponse>(
+      `${this.apiUrl}/wallet/create`,
+      request
+    );
   }
 
-  importKeystores(request: ImportKeystoresRequest): Observable<ImportKeystoresResponse> {
-    return this.http.post<ImportKeystoresResponse>(`${this.apiUrl}/wallet/keystores/import`, request);
+  importKeystores(
+    request: ImportKeystoresRequest
+  ): Observable<ImportKeystoresResponse> {
+    return this.http.post<ImportKeystoresResponse>(
+      `${this.apiUrl}/wallet/keystores/import`,
+      request
+    );
   }
 
   validateKeystores(request: ValidateKeystoresRequest): Observable<object> {
-    return this.http.post<object>(`${this.apiUrl}/wallet/keystores/validate`, request);
+    return this.http.post<object>(
+      `${this.apiUrl}/wallet/keystores/validate`,
+      request
+    );
   }
-  recover(request: RecoverWalletRequest):Observable<any>{
-    return this.http.post(`${this.apiUrl}/wallet/recover`, request)
+  recover(request: RecoverWalletRequest): Observable<any> {
+    return this.http.post(`${this.apiUrl}/wallet/recover`, request);
+  }
+  exitAccounts(request: AccountVoluntaryExitRequest) {
+    return this.http.post(`${this.apiUrl}/wallet/exit-accoints`, request);
   }
 }

--- a/src/app/modules/core/services/wallet.service.ts
+++ b/src/app/modules/core/services/wallet.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { map, share, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { EnvironmenterService } from './environmenter.service';
+import { RecoverWalletRequest } from '../../../proto/validator/accounts/v2/web_api';
 import {
   WalletResponse,
   GenerateMnemonicResponse,
@@ -72,5 +73,8 @@ export class WalletService {
 
   validateKeystores(request: ValidateKeystoresRequest): Observable<object> {
     return this.http.post<object>(`${this.apiUrl}/wallet/keystores/validate`, request);
+  }
+  recover(request: RecoverWalletRequest):Observable<any>{
+    return this.http.post(`${this.apiUrl}/wallet/recover`, request)
   }
 }

--- a/src/app/modules/core/validators/password.validator.ts
+++ b/src/app/modules/core/validators/password.validator.ts
@@ -1,5 +1,20 @@
 import { AbstractControl, Validators } from '@angular/forms';
 
+export abstract class StaticPasswordValidator{
+  static strongPassword = Validators.pattern(
+    /(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}/
+  );
+  static matchingPasswordConfirmation(control: AbstractControl): void {
+    const password: string = control.get('password')?.value;
+    const confirmPassword: string = control.get('passwordConfirmation')?.value;
+    if (password !== confirmPassword) {
+      control
+        .get('passwordConfirmation')
+        ?.setErrors({ passwordMismatch: true });
+    }
+  }
+}
+
 // PasswordValidator contains form validation for strong
 // password protection in the Prysm web UI.
 export class PasswordValidator {
@@ -21,22 +36,8 @@ export class PasswordValidator {
     /(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}/
   );
 
-  static strongPassword = Validators.pattern(
-    /(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}/
-  );
-
   // Ensure password and password confirmation field values match.
   matchingPasswordConfirmation(control: AbstractControl): void {
-    const password: string = control.get('password')?.value;
-    const confirmPassword: string = control.get('passwordConfirmation')?.value;
-    if (password !== confirmPassword) {
-      control
-        .get('passwordConfirmation')
-        ?.setErrors({ passwordMismatch: true });
-    }
-  }
-
-  static matchingPasswordConfirmation(control: AbstractControl): void {
     const password: string = control.get('password')?.value;
     const confirmPassword: string = control.get('passwordConfirmation')?.value;
     if (password !== confirmPassword) {

--- a/src/app/modules/core/validators/password.validator.ts
+++ b/src/app/modules/core/validators/password.validator.ts
@@ -9,7 +9,7 @@ export class PasswordValidator {
     required: 'Password is required',
     minLength: 'Password must be at least 8 characters',
     pattern: 'Requires at least 1 letter, number, and special character',
-    passwordMismatch: 'Passwords do not match'
+    passwordMismatch: 'Passwords do not match',
   };
 
   // Ensures a password has at least:
@@ -21,12 +21,28 @@ export class PasswordValidator {
     /(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}/
   );
 
+  static strongPassword = Validators.pattern(
+    /(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}/
+  );
+
   // Ensure password and password confirmation field values match.
   matchingPasswordConfirmation(control: AbstractControl): void {
     const password: string = control.get('password')?.value;
     const confirmPassword: string = control.get('passwordConfirmation')?.value;
     if (password !== confirmPassword) {
-      control.get('passwordConfirmation')?.setErrors({ passwordMismatch: true });
+      control
+        .get('passwordConfirmation')
+        ?.setErrors({ passwordMismatch: true });
+    }
+  }
+
+  static matchingPasswordConfirmation(control: AbstractControl): void {
+    const password: string = control.get('password')?.value;
+    const confirmPassword: string = control.get('passwordConfirmation')?.value;
+    if (password !== confirmPassword) {
+      control
+        .get('passwordConfirmation')
+        ?.setErrors({ passwordMismatch: true });
     }
   }
 }

--- a/src/app/modules/dashboard/components/activation-queue/activation-queue.component.spec.ts
+++ b/src/app/modules/dashboard/components/activation-queue/activation-queue.component.spec.ts
@@ -13,6 +13,7 @@ import { hexToBase64 } from 'src/app/modules/core/utils/hex-util';
 import { ChainService } from 'src/app/modules/core/services/chain.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { EnvironmenterService } from 'src/app/modules/core/services/environmenter.service';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ActivationQueueComponent', () => {
   let component: ActivationQueueComponent;
@@ -41,6 +42,7 @@ describe('ActivationQueueComponent', () => {
       declarations: [ ActivationQueueComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         HttpClientTestingModule,
       ],
       providers: [

--- a/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.spec.ts
+++ b/src/app/modules/dashboard/components/beacon-node-status/beacon-node-status.component.spec.ts
@@ -9,6 +9,7 @@ import { SharedModule } from 'src/app/modules/shared/shared.module';
 import { MockService } from 'ng-mocks';
 import { CommonModule } from '@angular/common';
 import { ChainHead } from 'src/app/proto/eth/v1alpha1/beacon_chain';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('BeaconNodeStatusComponent', () => {
   let component: BeaconNodeStatusComponent;
@@ -19,6 +20,7 @@ describe('BeaconNodeStatusComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
+        BrowserAnimationsModule,
         SharedModule,
       ],
       declarations: [ BeaconNodeStatusComponent ],

--- a/src/app/modules/dashboard/components/sidebar-expandable-link/sidebar-expandable-link.component.spec.ts
+++ b/src/app/modules/dashboard/components/sidebar-expandable-link/sidebar-expandable-link.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { SharedModule } from '../../../shared/shared.module';
 import { SidebarExpandableLinkComponent } from './sidebar-expandable-link.component';
@@ -11,6 +12,7 @@ describe('SidebarExpandableLinkComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ],
       declarations: [
         SidebarExpandableLinkComponent,

--- a/src/app/modules/dashboard/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/modules/dashboard/components/sidebar/sidebar.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SidebarComponent } from './sidebar.component';
 import { SharedModule } from '../../../shared/shared.module';
 import { SidebarExpandableLinkComponent } from '../sidebar-expandable-link/sidebar-expandable-link.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('SidebarComponent', () => {
   let component: SidebarComponent;
@@ -12,6 +13,7 @@ describe('SidebarComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ],
       declarations: [
         SidebarExpandableLinkComponent,

--- a/src/app/modules/dashboard/components/validator-participation/validator-participation.component.spec.ts
+++ b/src/app/modules/dashboard/components/validator-participation/validator-participation.component.spec.ts
@@ -9,6 +9,7 @@ import { ChainService } from 'src/app/modules/core/services/chain.service';
 import { ValidatorParticipationResponse } from 'src/app/proto/eth/v1alpha1/beacon_chain';
 import { ValidatorParticipation } from 'src/app/proto/eth/v1alpha1/validator';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ValidatorParticipationComponent', () => {
   let component: ValidatorParticipationComponent;
@@ -37,6 +38,7 @@ describe('ValidatorParticipationComponent', () => {
       declarations: [ ValidatorParticipationComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         MatTooltipModule,
       ],
       providers: [

--- a/src/app/modules/dashboard/components/validator-performance-list/validator-performance-list.component.spec.ts
+++ b/src/app/modules/dashboard/components/validator-performance-list/validator-performance-list.component.spec.ts
@@ -8,6 +8,7 @@ import {
 import { ValidatorPerformanceListComponent } from './validator-performance-list.component';
 import { of } from 'rxjs';
 import { ValidatorService } from '../../../core/services/validator.service';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ValidatorListComponent', () => {
   let component: ValidatorPerformanceListComponent;
@@ -34,6 +35,7 @@ describe('ValidatorListComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ],
       declarations: [ValidatorPerformanceListComponent],
       providers: [

--- a/src/app/modules/dashboard/components/validator-performance-summary/validator-performance-summary.component.spec.ts
+++ b/src/app/modules/dashboard/components/validator-performance-summary/validator-performance-summary.component.spec.ts
@@ -10,6 +10,7 @@ import { WalletService } from 'src/app/modules/core/services/wallet.service';
 import { BeaconNodeService } from 'src/app/modules/core/services/beacon-node.service';
 import { Peers } from 'src/app/proto/eth/v1alpha1/node';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ValidatorPerformanceSummaryComponent', () => {
   let component: ValidatorPerformanceSummaryComponent;
@@ -48,6 +49,7 @@ describe('ValidatorPerformanceSummaryComponent', () => {
       declarations: [ ValidatorPerformanceSummaryComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         MatTooltipModule,
       ],
       providers: [

--- a/src/app/modules/dashboard/components/version/version.component.spect.ts
+++ b/src/app/modules/dashboard/components/version/version.component.spect.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from '../../../shared/shared.module';
 import { VersionComponent } from './version.component';
 
@@ -10,6 +11,7 @@ describe('VersionComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ],
       declarations: [
         VersionComponent,

--- a/src/app/modules/dashboard/dashboard.component.spec.ts
+++ b/src/app/modules/dashboard/dashboard.component.spec.ts
@@ -10,6 +10,7 @@ import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { DashboardComponent } from './dashboard.component';
 import { BeaconNodeService } from '../core/services/beacon-node.service';
 import { BeaconStatusResponse } from 'src/app/proto/validator/accounts/v2/web_api';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -21,6 +22,7 @@ describe('DashboardComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
+        BrowserAnimationsModule,
         SharedModule,
       ],
       providers: [

--- a/src/app/modules/dashboard/dashboard.component.ts
+++ b/src/app/modules/dashboard/dashboard.component.ts
@@ -36,7 +36,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
         {
           name: 'Account List',
           icon: 'list',
-          path: '/dashboard/wallet/accounts',
+          path: '/dashboard/wallet',
         },
         {
           name: 'Wallet Information',

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -15,6 +15,7 @@ import { ValidatorParticipationComponent } from './components/validator-particip
 import { ValidatorPerformanceSummaryComponent } from './components/validator-performance-summary/validator-performance-summary.component';
 import { ActivationQueueComponent } from './components/activation-queue/activation-queue.component';
 import { VersionComponent } from './components/version/version.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [
@@ -32,6 +33,7 @@ import { VersionComponent } from './components/version/version.component';
   imports: [
     CommonModule,
     SharedModule,
+    BrowserAnimationsModule,
     RouterModule,
     NgxEchartsModule.forRoot({
       echarts: () => import('echarts'),

--- a/src/app/modules/dashboard/pages/gains-and-losses/gains-and-losses.component.spec.ts
+++ b/src/app/modules/dashboard/pages/gains-and-losses/gains-and-losses.component.spec.ts
@@ -14,6 +14,7 @@ import { ActivationQueueComponent } from '../../components/activation-queue/acti
 import { ValidatorService } from 'src/app/modules/core/services/validator.service';
 import { ChainService } from 'src/app/modules/core/services/chain.service';
 import { ENVIRONMENT } from 'src/environments/token';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('GainsAndLossesComponent', () => {
   let component: GainsAndLossesComponent;
@@ -23,6 +24,7 @@ describe('GainsAndLossesComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         HttpClientTestingModule,
         NgxEchartsModule.forRoot({
           echarts: () => import('echarts'),

--- a/src/app/modules/onboarding/components/choose-wallet-kind/choose-wallet-kind.component.html
+++ b/src/app/modules/onboarding/components/choose-wallet-kind/choose-wallet-kind.component.html
@@ -2,36 +2,40 @@
   <div class="text-center pb-8">
     <div class="text-white text-3xl">Create a Prysm Wallet</div>
     <div class="text-muted text-lg mt-6 leading-snug">
-      To get started, you will need to create a new wallet in Prysm<br/>to hold your validator keys
-    </div>
-  </div>
-  <div class="onboarding-grid flex-wrap flex justify-center items-center my-auto">
-    <div
-      *ngFor="let selection of walletSelections; index as idx"
-      class="bg-paper onboarding-card text-center flex flex-col my-8 md:my-0"
-      [class.active]="selectedCard === idx"
-      [class.mx-8]="idx === 1"
-      (click)="selectCard(idx)"
-    >
-      <div class="flex justify-center">
-        <img [src]="selection.image"/>
-      </div>
-      <div class="wallet-info">
-        <p class="wallet-kind">
-          {{selection.name}}
-        </p>
-        <p class="wallet-description">
-          {{selection.description}}
-        </p>
-        <p class="wallet-action">
-          <button *ngIf="!selection.comingSoon" class="select-button" mat-raised-button color="accent" (click)="selectedWallet$.next(selection.kind)">
-            Select Wallet
-          </button>
-          <button *ngIf="selection.comingSoon" class="select-button" mat-raised-button disabled>
-            Coming Soon
-          </button>
-        </p>
+      To get started, you will need to create a new wallet in Prysm<br/>to hold
+        your validator keys
       </div>
     </div>
+    <div class="onboarding-grid flex-wrap flex justify-center items-center
+      my-auto">
+      <div
+        *ngFor="let selection of walletSelections; index as idx"
+        class="bg-paper onboarding-card text-center flex flex-col my-8 md:my-0"
+        [class.active]="selectedCard === idx"
+        [class.mx-8]="idx === 1"
+        (click)="selectCard(idx)">
+        <div class="flex justify-center">
+          <img [src]="selection.image" />
+        </div>
+        <div class="wallet-info">
+          <p class="wallet-kind">
+            {{selection.name}}
+          </p>
+          <p class="wallet-description">
+            {{selection.description}}
+          </p>
+          <p class="wallet-action">
+            <button *ngIf="!selection.comingSoon" class="select-button"
+              mat-raised-button color="accent"
+              (click)="selectedWallet$.next(selection.kind)">
+              Select Wallet
+            </button>
+            <button *ngIf="selection.comingSoon" class="select-button"
+              mat-raised-button disabled>
+              Coming Soon
+            </button>
+          </p>
+        </div>
+      </div>
+    </div>
   </div>
-</div>

--- a/src/app/modules/onboarding/components/confirm-mnemonic/confirm-mnemonic.component.spec.ts
+++ b/src/app/modules/onboarding/components/confirm-mnemonic/confirm-mnemonic.component.spec.ts
@@ -5,6 +5,7 @@ import { By } from '@angular/platform-browser';
 import { ConfirmMnemonicComponent } from './confirm-mnemonic.component';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 import { BlockCopyPasteDirective } from '../../directives/block-copy-paste.directive';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 const SAMPLE_MNEMONIC = 'tape hungry front clump chapter blush alien sauce spawn victory mother salt purpose drop mask hour foil physical daughter narrow sheriff agree master survey';
 
@@ -24,6 +25,7 @@ describe('ConfirmMnemonicComponent', () => {
       ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         ReactiveFormsModule,
         FormsModule
       ]

--- a/src/app/modules/onboarding/components/generate-mnemonic/generate-mnemonic.component.spec.ts
+++ b/src/app/modules/onboarding/components/generate-mnemonic/generate-mnemonic.component.spec.ts
@@ -4,6 +4,7 @@ import { GenerateMnemonicComponent } from './generate-mnemonic.component';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
 import { of } from 'rxjs';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('GenerateMnemonicComponent', () => {
   let walletService: WalletService;
@@ -17,6 +18,7 @@ describe('GenerateMnemonicComponent', () => {
       declarations: [ GenerateMnemonicComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ],
       providers: [
         { provide: WalletService, useValue: spy },

--- a/src/app/modules/onboarding/components/wallet-directory-form/wallet-directory-form.component.spec.ts
+++ b/src/app/modules/onboarding/components/wallet-directory-form/wallet-directory-form.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MockService } from 'ng-mocks';
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
@@ -15,6 +16,7 @@ describe('WalletDirectoryFormComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         FormsModule,
         ReactiveFormsModule,
       ],

--- a/src/app/modules/onboarding/onboarding.component.html
+++ b/src/app/modules/onboarding/onboarding.component.html
@@ -10,7 +10,6 @@
     </div>
     <div *ngSwitchCase="States.RecoverWizard">
       <app-wallet-recover-wizard (onBackToWalletsRaised)="resetOnboarding()"></app-wallet-recover-wizard>
-      <!-- <app-hd-wallet-wizard [resetOnboarding]="resetOnboarding.bind(this)"></app-hd-wallet-wizard> -->
     </div>
   </div>
 </div>

--- a/src/app/modules/onboarding/onboarding.component.html
+++ b/src/app/modules/onboarding/onboarding.component.html
@@ -9,7 +9,7 @@
       <app-nonhd-wallet-wizard [resetOnboarding]="resetOnboarding.bind(this)"></app-nonhd-wallet-wizard>
     </div>
     <div *ngSwitchCase="States.RecoverWizard">
-      <app-wallet-recover-wizard (onBackToWalletsRaised)="resetOnboarding()"></app-wallet-recover-wizard>
+      <app-wallet-recover-wizard (backToWalletsRaised)="resetOnboarding()"></app-wallet-recover-wizard>
     </div>
   </div>
 </div>

--- a/src/app/modules/onboarding/onboarding.component.html
+++ b/src/app/modules/onboarding/onboarding.component.html
@@ -3,14 +3,14 @@
     <div *ngSwitchCase="States.PickingWallet">
       <app-choose-wallet-kind
         [walletSelections]="walletSelections"
-        [selectedWallet$]="selectedWallet$"
-      ></app-choose-wallet-kind>
+        [selectedWallet$]="selectedWallet$"></app-choose-wallet-kind>
     </div>
     <div *ngSwitchCase="States.ImportWizard">
       <app-nonhd-wallet-wizard [resetOnboarding]="resetOnboarding.bind(this)"></app-nonhd-wallet-wizard>
     </div>
     <div *ngSwitchCase="States.RecoverWizard">
-      <app-hd-wallet-wizard [resetOnboarding]="resetOnboarding.bind(this)"></app-hd-wallet-wizard>
+      <app-wallet-recover-wizard (onBackToWalletsRaised)="resetOnboarding()"></app-wallet-recover-wizard>
+      <!-- <app-hd-wallet-wizard [resetOnboarding]="resetOnboarding.bind(this)"></app-hd-wallet-wizard> -->
     </div>
   </div>
 </div>

--- a/src/app/modules/onboarding/onboarding.component.ts
+++ b/src/app/modules/onboarding/onboarding.component.ts
@@ -23,9 +23,9 @@ export class OnboardingComponent implements OnInit, OnDestroy {
     {
       kind: WalletKind.Derived,
       name: 'Recover a Wallet',
-      description: 'Use a 24-word mnemonic phrase to recover existing eth2 keystores',
+      description:
+        'Use a 24-word mnemonic phrase to recover existing eth2 keystores',
       image: '/assets/images/onboarding/lock.svg',
-      comingSoon: true,
     },
     {
       kind: WalletKind.Imported,
@@ -42,25 +42,27 @@ export class OnboardingComponent implements OnInit, OnDestroy {
   // as this fires. This subject will fire in ngOnDestroy.
   destroyed$ = new Subject();
 
-  constructor() { }
+  constructor() {}
 
   ngOnInit(): void {
-    this.selectedWallet$.pipe(
-      tap(kind => {
-        switch (kind) {
-          case WalletKind.Derived:
-            this.onboardingState = OnboardingState.RecoverWizard;
-            break;
-          case WalletKind.Imported:
-            this.onboardingState = OnboardingState.ImportWizard;
-            break;
-          default:
-            break;
-        }
-      }),
-      takeUntil(this.destroyed$),
-      catchError(err => throwError(err)),
-    ).subscribe();
+    this.selectedWallet$
+      .pipe(
+        tap((kind) => {
+          switch (kind) {
+            case WalletKind.Derived:
+              this.onboardingState = OnboardingState.RecoverWizard;
+              break;
+            case WalletKind.Imported:
+              this.onboardingState = OnboardingState.ImportWizard;
+              break;
+            default:
+              break;
+          }
+        }),
+        takeUntil(this.destroyed$),
+        catchError((err) => throwError(err))
+      )
+      .subscribe();
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/onboarding/onboarding.module.ts
+++ b/src/app/modules/onboarding/onboarding.module.ts
@@ -19,6 +19,7 @@ import { NonhdWalletWizardComponent } from './pages/nonhd-wallet-wizard/nonhd-wa
 import { WalletDirectoryFormComponent } from './components/wallet-directory-form/wallet-directory-form.component';
 import { WalletRecoverWizardComponent } from './pages/wallet-recover-wizard/wallet-recover-wizard.component';
 import { MnemonicFormComponent } from './pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [
@@ -37,6 +38,7 @@ import { MnemonicFormComponent } from './pages/wallet-recover-wizard/templates/m
   imports: [
     CommonModule,
     SharedModule,
+    BrowserAnimationsModule,
     RouterModule,
     ReactiveFormsModule,
     FormsModule,

--- a/src/app/modules/onboarding/onboarding.module.ts
+++ b/src/app/modules/onboarding/onboarding.module.ts
@@ -17,6 +17,8 @@ import { MnemonicValidator } from './validators/mnemonic.validator';
 import { HdWalletWizardComponent } from './pages/hd-wallet-wizard/hd-wallet-wizard.component';
 import { NonhdWalletWizardComponent } from './pages/nonhd-wallet-wizard/nonhd-wallet-wizard.component';
 import { WalletDirectoryFormComponent } from './components/wallet-directory-form/wallet-directory-form.component';
+import { WalletRecoverWizardComponent } from './pages/wallet-recover-wizard/wallet-recover-wizard.component';
+import { MnemonicFormComponent } from './pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component';
 
 @NgModule({
   declarations: [
@@ -28,6 +30,8 @@ import { WalletDirectoryFormComponent } from './components/wallet-directory-form
     ConfirmMnemonicComponent,
     NonhdWalletWizardComponent,
     WalletDirectoryFormComponent,
+    WalletRecoverWizardComponent,
+    MnemonicFormComponent,
   ],
   providers: [MnemonicValidator],
   imports: [

--- a/src/app/modules/onboarding/pages/hd-wallet-wizard/hd-wallet-wizard.component.spec.ts
+++ b/src/app/modules/onboarding/pages/hd-wallet-wizard/hd-wallet-wizard.component.spec.ts
@@ -19,6 +19,7 @@ import {
   CreateWalletResponse,
   AuthRequest,
 } from 'src/app/proto/validator/accounts/v2/web_api';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('HdWalletWizardComponent', () => {
   let component: HdWalletWizardComponent;
@@ -49,6 +50,7 @@ describe('HdWalletWizardComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         SharedModule,
+        BrowserAnimationsModule,
         HttpClientTestingModule,
       ],
       providers: [

--- a/src/app/modules/onboarding/pages/nonhd-wallet-wizard/nonhd-wallet-wizard.component.spec.ts
+++ b/src/app/modules/onboarding/pages/nonhd-wallet-wizard/nonhd-wallet-wizard.component.spec.ts
@@ -11,6 +11,7 @@ import { SharedModule } from 'src/app/modules/shared/shared.module';
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
 import { AuthenticationService } from 'src/app/modules/core/services/authentication.service';
 import { WalletResponse, AuthResponse, CreateWalletRequest, CreateWalletResponse, AuthRequest } from 'src/app/proto/validator/accounts/v2/web_api';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('NonhdWalletWizardComponent', () => {
   let component: NonhdWalletWizardComponent;
@@ -39,6 +40,7 @@ describe('NonhdWalletWizardComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         SharedModule,
+        BrowserAnimationsModule,
         HttpClientTestingModule,
       ],
       providers: [

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.html
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.html
@@ -1,6 +1,4 @@
-
-
-<form [formGroup]="fg" (ngSubmit)="next()">
+<form *ngIf="fg" [formGroup]="fg" (ngSubmit)="next()">
     <div class="my-4 text-hint text-lg leading-snug">
         Enter all 24 words for your mnemonic from the previous step to
         proceed.
@@ -39,7 +37,6 @@
             </span>
         </mat-error>
     </mat-form-field>
-
     <div class="mt-6">
         <button color="accent" type="button" mat-raised-button
             (click)="onBackToWalletsRaised.emit()">Back

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.html
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.html
@@ -1,0 +1,50 @@
+
+
+<form [formGroup]="fg" (ngSubmit)="next()">
+    <div class="my-4 text-hint text-lg leading-snug">
+        Enter all 24 words for your mnemonic from the previous step to
+        proceed.
+        Remember this is the <span class="text-error font-semibold">only way</span>
+        you can recover your validator keys if you lose your wallet.
+    </div>
+    <mat-form-field [appearance]="'outline'">
+        <mat-label>Mnemonic</mat-label>
+        <textarea cdkAutosizeMinRows="3"
+            cdkTextareaAutosize
+            cdkAutosizeMaxRows="4" matInput appBlockCopyPaste
+            formControlName="mnemonic"></textarea>
+        <mat-error>
+            <span *ngIf="fg.controls.mnemonic.hasError('required')">
+                The mnemonics are required
+            </span>
+            <span *ngIf="fg.controls.mnemonic.hasError('properFormatting')">
+                Must contain 24 words separated by spaces
+            </span>
+            <span
+                *ngIf="fg?.controls.mnemonic.hasError('mnemonicMismatch')">
+                Entered mnemonic does not match original
+            </span>
+        </mat-error>
+    </mat-form-field>
+    <mat-form-field [appearance]="'outline'">
+        <mat-label>Num accounts</mat-label>
+        <input type="number" matInput formControlName="num_accounts" />
+        <mat-error>
+            <span *ngIf="fg.controls.num_accounts.hasError('required')">
+                The number of accounts is required
+            </span>
+            <span
+                *ngIf="fg.controls.num_accounts.hasError('BiggerThanZero')">
+                The number of accounts must be bigger than zero
+            </span>
+        </mat-error>
+    </mat-form-field>
+
+    <div class="mt-6">
+        <button color="accent" type="button" mat-raised-button
+            (click)="onBackToWalletsRaised.emit()">Back
+            to Wallets</button>
+        <span class="ml-4"><button color="primary" mat-raised-button
+                [disabled]="fg.invalid">Continue</button></span>
+    </div>
+</form>

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.html
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.html
@@ -24,19 +24,7 @@
             </span>
         </mat-error>
     </mat-form-field>
-    <mat-form-field [appearance]="'outline'">
-        <mat-label>Num accounts</mat-label>
-        <input type="number" matInput formControlName="num_accounts" />
-        <mat-error>
-            <span *ngIf="fg.controls.num_accounts.hasError('required')">
-                The number of accounts is required
-            </span>
-            <span
-                *ngIf="fg.controls.num_accounts.hasError('BiggerThanZero')">
-                The number of accounts must be bigger than zero
-            </span>
-        </mat-error>
-    </mat-form-field>
+    <app-create-accounts-form #numAccounts [formGroup]="numAccountsFg"></app-create-accounts-form>
     <div class="mt-6">
         <button color="accent" type="button" mat-raised-button
             (click)="onBackToWalletsRaised.emit()">Back

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.spec.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.spec.ts
@@ -1,4 +1,7 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { MnemonicFormComponent } from './mnemonic-form.component';
 
@@ -8,9 +11,14 @@ describe('MnemonicFormComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ MnemonicFormComponent ]
-    })
-    .compileComponents();
+      declarations: [MnemonicFormComponent],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        SharedModule,
+        HttpClientTestingModule,
+      ],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.spec.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { MnemonicFormComponent } from './mnemonic-form.component';
@@ -16,6 +17,8 @@ describe('MnemonicFormComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         SharedModule,
+        BrowserAnimationsModule,
+        
         HttpClientTestingModule,
       ],
     }).compileComponents();

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.spec.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.spec.ts
@@ -18,7 +18,6 @@ describe('MnemonicFormComponent', () => {
         ReactiveFormsModule,
         SharedModule,
         BrowserAnimationsModule,
-        
         HttpClientTestingModule,
       ],
     }).compileComponents();

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.spec.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MnemonicFormComponent } from './mnemonic-form.component';
+
+describe('MnemonicFormComponent', () => {
+  let component: MnemonicFormComponent;
+  let fixture: ComponentFixture<MnemonicFormComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MnemonicFormComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MnemonicFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-mnemonic-form',
+  templateUrl: './mnemonic-form.component.html',
+  styleUrls: ['./mnemonic-form.component.scss'],
+})
+export class MnemonicFormComponent implements OnInit {
+  @Input('fg') fg!: FormGroup;
+  @Output('onNext') onNext = new EventEmitter<FormGroup>();
+  @Output('onBackToWalletsRaised')
+  onBackToWalletsRaised = new EventEmitter<void>();
+  constructor() {}
+
+  ngOnInit(): void {}
+  next() {
+    this.onNext.emit(this.fg);
+  }
+}

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.ts
@@ -10,10 +10,9 @@ import { BaseComponent } from '../../../../../shared/components/base.component';
   styleUrls: ['./mnemonic-form.component.scss'],
 })
 export class MnemonicFormComponent extends BaseComponent implements OnInit {
-  @Input('fg') fg: FormGroup | null = null;
-  @Output('onNext') onNext = new EventEmitter<FormGroup>();
-  @Output('onBackToWalletsRaised')
-  onBackToWalletsRaised = new EventEmitter<void>();
+  @Input() fg: FormGroup | null = null;
+  @Output() nextRaised = new EventEmitter<FormGroup>();
+  @Output() backToWalletsRaised = new EventEmitter<void>();
   constructor(private fb: FormBuilder) {
     super();
   }
@@ -32,16 +31,20 @@ export class MnemonicFormComponent extends BaseComponent implements OnInit {
     this.numAccountsFg.valueChanges
       .pipe(takeUntil(this.destroyed$))
       .subscribe((val) => {
-        if (this.fg) this.passValueToNum_Accounts(this.fg);
+        if (this.fg) {
+          this.passValueToNum_Accounts(this.fg);
+        }
       });
   }
-  next() {
-    if (!this.fg) return;
+  next(): void {
+    if (!this.fg) {
+      return;
+    }
     this.passValueToNum_Accounts(this.fg);
-    this.onNext.emit(this.fg);
+    this.nextRaised.emit(this.fg);
   }
 
-  private passValueToNum_Accounts(fg: FormGroup) {
+  private passValueToNum_Accounts(fg: FormGroup): void {
     fg.get('num_accounts')?.setValue(
       this.numAccountsFg.get('numAccounts')?.value
     );

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.ts
@@ -1,21 +1,49 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MAX_ACCOUNTS_CREATION } from 'src/app/modules/core/constants';
+import { takeUntil } from 'rxjs/operators';
+import { BaseComponent } from '../../../../../shared/components/base.component';
 
 @Component({
   selector: 'app-mnemonic-form',
   templateUrl: './mnemonic-form.component.html',
   styleUrls: ['./mnemonic-form.component.scss'],
 })
-export class MnemonicFormComponent implements OnInit {
+export class MnemonicFormComponent extends BaseComponent implements OnInit {
   @Input('fg') fg: FormGroup | null = null;
   @Output('onNext') onNext = new EventEmitter<FormGroup>();
   @Output('onBackToWalletsRaised')
   onBackToWalletsRaised = new EventEmitter<void>();
-  constructor() {}
+  constructor(private fb: FormBuilder) {
+    super();
+  }
 
-  ngOnInit(): void {}
+  numAccountsFg = this.fb.group({
+    numAccounts: [
+      1,
+      [
+        Validators.required,
+        Validators.min(1),
+        Validators.max(MAX_ACCOUNTS_CREATION),
+      ],
+    ],
+  });
+  ngOnInit(): void {
+    this.numAccountsFg.valueChanges
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe((val) => {
+        if (this.fg) this.passValueToNum_Accounts(this.fg);
+      });
+  }
   next() {
     if (!this.fg) return;
+    this.passValueToNum_Accounts(this.fg);
     this.onNext.emit(this.fg);
+  }
+
+  private passValueToNum_Accounts(fg: FormGroup) {
+    fg.get('num_accounts')?.setValue(
+      this.numAccountsFg.get('numAccounts')?.value
+    );
   }
 }

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/templates/mnemonic-form/mnemonic-form.component.ts
@@ -7,7 +7,7 @@ import { FormGroup } from '@angular/forms';
   styleUrls: ['./mnemonic-form.component.scss'],
 })
 export class MnemonicFormComponent implements OnInit {
-  @Input('fg') fg!: FormGroup;
+  @Input('fg') fg: FormGroup | null = null;
   @Output('onNext') onNext = new EventEmitter<FormGroup>();
   @Output('onBackToWalletsRaised')
   onBackToWalletsRaised = new EventEmitter<void>();
@@ -15,6 +15,7 @@ export class MnemonicFormComponent implements OnInit {
 
   ngOnInit(): void {}
   next() {
+    if (!this.fg) return;
     this.onNext.emit(this.fg);
   }
 }

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.html
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.html
@@ -22,8 +22,8 @@
                             <mat-step [stepControl]="mnemonicFg"
                                 label="Mnemonics">
                                 <app-mnemonic-form
-                                    (onBackToWalletsRaised)="onBackToWalletsRaised.emit()"
-                                    (onNext)="onNext(horizontalStepper,mnemonicFg,$event)"
+                                    (backToWalletsRaised)="backToWalletsRaised.emit()"
+                                    (nextRaised)="onNext(horizontalStepper,mnemonicFg,$event)"
                                     [fg]="mnemonicFg"></app-mnemonic-form>
                             </mat-step>
                             <mat-step [stepControl]="passwordFG" label="Web
@@ -71,7 +71,7 @@
                             <mat-step [stepControl]="mnemonicFg"
                                 label="Mnemonics">
                                 <app-mnemonic-form
-                                    (onBackToWalletsRaised)="onBackToWalletsRaised.emit()"
+                                    (onBackToWalletsRaised)="backToWalletsRaised.emit()"
                                     (onNext)="onNext(verticalStepper,mnemonicFg,$event)"
                                     [fg]="mnemonicFg"></app-mnemonic-form>
                             </mat-step>

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.html
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.html
@@ -1,0 +1,122 @@
+<div class="create-a-wallet">
+    <div class="text-center pb-8">
+        <div class="text-white text-3xl">Recovery Wallet Setup</div>
+        <div class="text-muted text-lg mt-6 leading-snug">
+            We'll guide you through the recovery of your wallet
+        </div>
+    </div>
+
+    <div class="onboarding-grid flex justify-center items-center my-auto">
+        <mat-card class="onboarding-wizard-card position-relative y-center">
+            <div class="flex items-center">
+                <div class="hidden md:flex w-1/3 signup-img justify-center
+                    items-center">
+                    <img src="/assets/images/onboarding/lock.svg" alt="" />
+                </div>
+                <div class="wizard-container md:flex md:w-2/3
+                    items-center">
+                    <mat-card-content>
+                        <mat-horizontal-stepper *ngIf="!isSmallScreen"
+                            #horizontalStepper
+                            [linear]="true">
+                            <mat-step [stepControl]="mnemonicFg"
+                                label="Mnemonics">
+                                <app-mnemonic-form
+                                    (onBackToWalletsRaised)="onBackToWalletsRaised.emit()"
+                                    (onNext)="onNext(horizontalStepper,mnemonicFg,$event)"
+                                    [fg]="mnemonicFg"></app-mnemonic-form>
+                            </mat-step>
+                            <mat-step [stepControl]="passwordFG" label="Web
+                                password">
+                                <app-password-form
+                                    #passwordForm
+                                    title="Web UI Password"
+                                    subtitle="You'll need to input this password
+                                    every time you log back into the web
+                                    interface"
+                                    label="Web password"
+                                    confirmationLabel="Confirm web password"
+                                    [formGroup]="passwordFG"></app-password-form>
+                                <div class="mt-4">
+                                    <button color="accent" mat-raised-button
+                                        (click)="horizontalStepper.previous()">Previous</button>
+                                    <span class="ml-4"><button color="primary"
+                                            mat-raised-button
+                                            (click)="login(horizontalStepper,passwordFG,passwordForm?.formGroup)">Continue</button></span>
+                                </div>
+                            </mat-step>
+                            <mat-step [stepControl]="walletPasswordFg"
+                                label="Wallet password">
+                                <app-password-form
+                                    #walletForm
+                                    title="Wallet Password"
+                                    subtitle="You'll need to input this password
+                                    every time you log back into the web
+                                    interface"
+                                    label="Wallet password"
+                                    confirmationLabel="Confirm wallet password"
+                                    [formGroup]="walletPasswordFg"></app-password-form>
+                                <div class="mt-4">
+                                    <button color="accent" mat-raised-button
+                                        (click)="horizontalStepper.previous()">Previous</button>
+                                    <span class="ml-4"><button color="primary"
+                                            mat-raised-button
+                                            (click)="walletRecover(walletForm.formGroup)">Continue</button></span>
+                                </div>
+                            </mat-step>
+                        </mat-horizontal-stepper>
+
+                        <mat-vertical-stepper *ngIf="isSmallScreen"
+                            #verticalStepper [linear]="true">
+                            <mat-step [stepControl]="mnemonicFg"
+                                label="Mnemonics">
+                                <app-mnemonic-form
+                                    (onBackToWalletsRaised)="onBackToWalletsRaised.emit()"
+                                    (onNext)="onNext(verticalStepper,mnemonicFg,$event)"
+                                    [fg]="mnemonicFg"></app-mnemonic-form>
+                            </mat-step>
+                            <mat-step [stepControl]="passwordFG" label="Web
+                                password">
+                                <app-password-form
+                                    #passwordForm
+                                    title="Web UI Password"
+                                    subtitle="You'll need to input this password
+                                    every time you log back into the web
+                                    interface"
+                                    label="Web password"
+                                    confirmationLabel="Confirm web password"
+                                    [formGroup]="passwordFG"></app-password-form>
+                                <div class="mt-4">
+                                    <button color="accent" mat-raised-button
+                                        (click)="verticalStepper.previous()">Previous</button>
+                                    <span class="ml-4"><button color="primary"
+                                            mat-raised-button
+                                            (click)="login(verticalStepper,passwordFG,passwordForm?.formGroup)">Continue</button></span>
+                                </div>
+                            </mat-step>
+                            <mat-step [stepControl]="walletPasswordFg"
+                                label="Wallet password">
+                                <app-password-form
+                                    #walletForm
+                                    title="Wallet Password"
+                                    subtitle="You'll need to input this password
+                                    every time you log back into the web
+                                    interface"
+                                    label="Wallet password"
+                                    confirmationLabel="Confirm wallet password"
+                                    [formGroup]="walletPasswordFg"></app-password-form>
+                                <div class="mt-4">
+                                    <button color="accent" mat-raised-button
+                                        (click)="verticalStepper.previous()">Previous</button>
+                                    <span class="ml-4"><button color="primary"
+                                            mat-raised-button
+                                            (click)="walletRecover(walletForm.formGroup)">Continue</button></span>
+                                </div>
+                            </mat-step>
+                        </mat-vertical-stepper>
+                    </mat-card-content>
+                </div>
+            </div>
+        </mat-card>
+    </div>
+</div>

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.spec.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../../proto/validator/accounts/v2/web_api';
 import { of } from 'rxjs';
 import { MatStepper } from '@angular/material/stepper';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('WalletRecoverWizardComponent', () => {
   let component: WalletRecoverWizardComponent;
@@ -51,6 +52,7 @@ describe('WalletRecoverWizardComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         SharedModule,
+        BrowserAnimationsModule,
         HttpClientTestingModule,
       ],
     }).compileComponents();

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.spec.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.spec.ts
@@ -1,16 +1,61 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+  FormControl,
+  FormBuilder,
+  AbstractControlOptions,
+} from '@angular/forms';
+import { MockService } from 'ng-mocks';
+import { AuthenticationService } from 'src/app/modules/core/services/authentication.service';
+import { WalletService } from 'src/app/modules/core/services/wallet.service';
+import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { WalletRecoverWizardComponent } from './wallet-recover-wizard.component';
+import {
+  RecoverWalletRequest,
+  AuthRequest,
+  AuthResponse,
+} from '../../../../proto/validator/accounts/v2/web_api';
+import { of } from 'rxjs';
+import { MatStepper } from '@angular/material/stepper';
 
 describe('WalletRecoverWizardComponent', () => {
   let component: WalletRecoverWizardComponent;
   let fixture: ComponentFixture<WalletRecoverWizardComponent>;
+  let walletService: WalletService;
+  let authService: AuthenticationService;
+  let formBuilder: FormBuilder;
 
   beforeEach(async(() => {
+    walletService = MockService(WalletService);
+    authService = MockService(AuthenticationService);
+    walletService.recover = (req: RecoverWalletRequest) => {
+      return of({});
+    };
+    authService.signup = (req: AuthRequest) => {
+      return of(<AuthResponse>{
+        token: 'NewToken',
+      });
+    };
+
     TestBed.configureTestingModule({
-      declarations: [ WalletRecoverWizardComponent ]
-    })
-    .compileComponents();
+      declarations: [WalletRecoverWizardComponent],
+      providers: [
+        { provide: AuthenticationService, useValue: authService },
+        { provide: WalletService, useValue: walletService },
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        SharedModule,
+        HttpClientTestingModule,
+      ],
+    }).compileComponents();
+    walletService = TestBed.inject(WalletService);
+    authService = TestBed.inject(AuthenticationService);
   }));
 
   beforeEach(() => {
@@ -21,5 +66,16 @@ describe('WalletRecoverWizardComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+  it('should pass value to new form group', () => {
+    const st = <MatStepper>{
+      next: () => {},
+    };
+    let oldFg = new FormGroup({});
+    let newFg = new FormGroup({
+      firstKey: new FormControl(''),
+    });
+    oldFg = component.onNext(st, oldFg, newFg);
+    expect(oldFg.value).toEqual(newFg.value);
   });
 });

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.spec.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WalletRecoverWizardComponent } from './wallet-recover-wizard.component';
+
+describe('WalletRecoverWizardComponent', () => {
+  let component: WalletRecoverWizardComponent;
+  let fixture: ComponentFixture<WalletRecoverWizardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ WalletRecoverWizardComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WalletRecoverWizardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.spec.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.spec.ts
@@ -28,7 +28,6 @@ describe('WalletRecoverWizardComponent', () => {
   let fixture: ComponentFixture<WalletRecoverWizardComponent>;
   let walletService: WalletService;
   let authService: AuthenticationService;
-  let formBuilder: FormBuilder;
 
   beforeEach(async(() => {
     walletService = MockService(WalletService);
@@ -37,9 +36,9 @@ describe('WalletRecoverWizardComponent', () => {
       return of({});
     };
     authService.signup = (req: AuthRequest) => {
-      return of(<AuthResponse>{
+      return of({
         token: 'NewToken',
-      });
+      } as AuthResponse);
     };
 
     TestBed.configureTestingModule({
@@ -70,14 +69,14 @@ describe('WalletRecoverWizardComponent', () => {
     expect(component).toBeTruthy();
   });
   it('should pass value to new form group', () => {
-    const st = <MatStepper>{
+    const st = {
       next: () => {},
-    };
+    } as MatStepper;
     let oldFg = new FormGroup({});
-    let newFg = new FormGroup({
+    const newFg = new FormGroup({
       firstKey: new FormControl(''),
     });
-    oldFg = component.onNext(st, oldFg, newFg);
+    oldFg = component.onNext(st, oldFg, newFg) as FormGroup;
     expect(oldFg.value).toEqual(newFg.value);
   });
 });

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.ts
@@ -103,6 +103,7 @@ export class WalletRecoverWizardComponent
   onNext(st: MatStepper, oldForm: FormGroup, newForm: FormGroup) {
     oldForm = newForm;
     st?.next();
+    return oldForm
   }
   login(st: MatStepper, oldForm: FormGroup, newForm: FormGroup) {
     this.authService.signup(newForm.value).subscribe((response) => {
@@ -112,9 +113,9 @@ export class WalletRecoverWizardComponent
   walletRecover(form: FormGroup) {
     if (form.invalid) return;
     const request = <RecoverWalletRequest>{
-      Mnemonic: this.mnemonicFg.get('mnemonic')?.value,
-      Num_accounts: this.mnemonicFg.get('num_accounts')?.value,
-      Wallet_password: form.get('password')?.value,
+      mnemonic: this.mnemonicFg.get('mnemonic')?.value,
+      num_accounts: this.mnemonicFg.get('num_accounts')?.value,
+      wallet_password: form.get('password')?.value,
     };
     this.walletService.recover(request).subscribe((x) => {
       this.onBackToWalletsRaised.emit();

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.ts
@@ -14,13 +14,14 @@ import {
 import { MnemonicValidator } from '../../validators/mnemonic.validator';
 import { UtilityValidator } from '../../validators/utility.validator';
 import { MatStepper } from '@angular/material/stepper';
-import { PasswordValidator } from '../../../core/validators/password.validator';
+
 import { AuthenticationService } from '../../../core/services/authentication.service';
 import { WalletService } from '../../../core/services/wallet.service';
 import { RecoverWalletRequest } from 'src/app/proto/validator/accounts/v2/web_api';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { takeUntil, tap } from 'rxjs/operators';
 import { BaseComponent } from '../../../shared/components/base.component';
+import { StaticPasswordValidator } from '../../../core/validators/password.validator';
 
 @Component({
   selector: 'app-wallet-recover-wizard',
@@ -30,13 +31,12 @@ import { BaseComponent } from '../../../shared/components/base.component';
 export class WalletRecoverWizardComponent
   extends BaseComponent
   implements OnInit {
-  @Output('onBackToWalletsRaised')
-  onBackToWalletsRaised = new EventEmitter<void>();
+  @Output() backToWalletsRaised = new EventEmitter<void>();
   @ViewChild('horizontalStepper', { static: true }) stepper?: MatStepper;
   mnemonicFg!: FormGroup;
   passwordFG!: FormGroup;
   walletPasswordFg!: FormGroup;
-  isSmallScreen: boolean = false;
+  isSmallScreen = false;
   constructor(
     private fb: FormBuilder,
     private authService: AuthenticationService,
@@ -61,17 +61,17 @@ export class WalletRecoverWizardComponent
           [
             Validators.required,
             Validators.minLength(8),
-            PasswordValidator.strongPassword,
+            StaticPasswordValidator.strongPassword,
           ]
         ),
         passwordConfirmation: new FormControl('', [
           Validators.required,
           Validators.minLength(8),
-          PasswordValidator.strongPassword,
+          StaticPasswordValidator.strongPassword,
         ]),
       },
       {
-        validators: PasswordValidator.matchingPasswordConfirmation,
+        validators: StaticPasswordValidator.matchingPasswordConfirmation,
       }
     );
     this.walletPasswordFg = this.fb.group(
@@ -82,17 +82,17 @@ export class WalletRecoverWizardComponent
           [
             Validators.required,
             Validators.minLength(8),
-            PasswordValidator.strongPassword,
+            StaticPasswordValidator.strongPassword,
           ]
         ),
         passwordConfirmation: new FormControl('', [
           Validators.required,
           Validators.minLength(8),
-          PasswordValidator.strongPassword,
+          StaticPasswordValidator.strongPassword,
         ]),
       },
       {
-        validators: PasswordValidator.matchingPasswordConfirmation,
+        validators: StaticPasswordValidator.matchingPasswordConfirmation,
       }
     );
   }
@@ -100,27 +100,37 @@ export class WalletRecoverWizardComponent
   ngOnInit(): void {
     this.registerBreakpointObserver();
   }
-  onNext(st: MatStepper, oldForm: FormGroup, newForm: FormGroup) {
+
+  onNext(
+    st: MatStepper,
+    oldForm: FormGroup,
+    newForm: FormGroup
+  ): void | FormGroup {
     oldForm = newForm;
     st?.next();
-    return oldForm
+    return oldForm;
   }
-  login(st: MatStepper, oldForm: FormGroup, newForm: FormGroup) {
+
+  login(st: MatStepper, oldForm: FormGroup, newForm: FormGroup): void {
     this.authService.signup(newForm.value).subscribe((response) => {
       this.onNext(st, oldForm, newForm);
     });
   }
-  walletRecover(form: FormGroup) {
-    if (form.invalid) return;
-    const request = <RecoverWalletRequest>{
+
+  walletRecover(form: FormGroup): void {
+    if (form.invalid) {
+      return;
+    }
+    const request = {
       mnemonic: this.mnemonicFg.get('mnemonic')?.value,
       num_accounts: this.mnemonicFg.get('num_accounts')?.value,
       wallet_password: form.get('password')?.value,
-    };
+    } as RecoverWalletRequest;
     this.walletService.recover(request).subscribe((x) => {
-      this.onBackToWalletsRaised.emit();
+      this.backToWalletsRaised.emit();
     });
   }
+
   registerBreakpointObserver(): void {
     this.breakpointObserver
       .observe([Breakpoints.XSmall, Breakpoints.Small])

--- a/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.ts
+++ b/src/app/modules/onboarding/pages/wallet-recover-wizard/wallet-recover-wizard.component.ts
@@ -1,0 +1,134 @@
+import {
+  Component,
+  EventEmitter,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import {
+  FormGroup,
+  FormBuilder,
+  Validators,
+  FormControl,
+} from '@angular/forms';
+import { MnemonicValidator } from '../../validators/mnemonic.validator';
+import { UtilityValidator } from '../../validators/utility.validator';
+import { MatStepper } from '@angular/material/stepper';
+import { PasswordValidator } from '../../../core/validators/password.validator';
+import { AuthenticationService } from '../../../core/services/authentication.service';
+import { WalletService } from '../../../core/services/wallet.service';
+import { RecoverWalletRequest } from 'src/app/proto/validator/accounts/v2/web_api';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { takeUntil, tap } from 'rxjs/operators';
+import { BaseComponent } from '../../../shared/components/base.component';
+
+@Component({
+  selector: 'app-wallet-recover-wizard',
+  templateUrl: './wallet-recover-wizard.component.html',
+  styleUrls: ['./wallet-recover-wizard.component.scss'],
+})
+export class WalletRecoverWizardComponent
+  extends BaseComponent
+  implements OnInit {
+  @Output('onBackToWalletsRaised')
+  onBackToWalletsRaised = new EventEmitter<void>();
+  @ViewChild('horizontalStepper', { static: true }) stepper?: MatStepper;
+  mnemonicFg!: FormGroup;
+  passwordFG!: FormGroup;
+  walletPasswordFg!: FormGroup;
+  isSmallScreen: boolean = false;
+  constructor(
+    private fb: FormBuilder,
+    private authService: AuthenticationService,
+    private breakpointObserver: BreakpointObserver,
+    private walletService: WalletService,
+    private mnemonicValidator: MnemonicValidator
+  ) {
+    super();
+    this.mnemonicFg = this.fb.group({
+      mnemonic: [
+        '',
+        [Validators.required, this.mnemonicValidator.properFormatting],
+        [this.mnemonicValidator.matchingMnemonic()],
+      ],
+      num_accounts: [1, [Validators.required, UtilityValidator.BiggerThanZero]],
+    });
+    this.passwordFG = this.fb.group(
+      {
+        password: new FormControl(
+          '',
+
+          [
+            Validators.required,
+            Validators.minLength(8),
+            PasswordValidator.strongPassword,
+          ]
+        ),
+        passwordConfirmation: new FormControl('', [
+          Validators.required,
+          Validators.minLength(8),
+          PasswordValidator.strongPassword,
+        ]),
+      },
+      {
+        validators: PasswordValidator.matchingPasswordConfirmation,
+      }
+    );
+    this.walletPasswordFg = this.fb.group(
+      {
+        password: new FormControl(
+          '',
+
+          [
+            Validators.required,
+            Validators.minLength(8),
+            PasswordValidator.strongPassword,
+          ]
+        ),
+        passwordConfirmation: new FormControl('', [
+          Validators.required,
+          Validators.minLength(8),
+          PasswordValidator.strongPassword,
+        ]),
+      },
+      {
+        validators: PasswordValidator.matchingPasswordConfirmation,
+      }
+    );
+  }
+
+  ngOnInit(): void {
+    this.registerBreakpointObserver();
+  }
+  onNext(st: MatStepper, oldForm: FormGroup, newForm: FormGroup) {
+    oldForm = newForm;
+    st?.next();
+  }
+  login(st: MatStepper, oldForm: FormGroup, newForm: FormGroup) {
+    this.authService.signup(newForm.value).subscribe((response) => {
+      this.onNext(st, oldForm, newForm);
+    });
+  }
+  walletRecover(form: FormGroup) {
+    if (form.invalid) return;
+    const request = <RecoverWalletRequest>{
+      Mnemonic: this.mnemonicFg.get('mnemonic')?.value,
+      Num_accounts: this.mnemonicFg.get('num_accounts')?.value,
+      Wallet_password: form.get('password')?.value,
+    };
+    this.walletService.recover(request).subscribe((x) => {
+      this.onBackToWalletsRaised.emit();
+    });
+  }
+  registerBreakpointObserver(): void {
+    this.breakpointObserver
+      .observe([Breakpoints.XSmall, Breakpoints.Small])
+      .pipe(
+        tap((result) => {
+          this.isSmallScreen = result.matches;
+        }),
+        takeUntil(this.destroyed$)
+      )
+      .subscribe();
+  }
+}

--- a/src/app/modules/onboarding/validators/utility.validator.ts
+++ b/src/app/modules/onboarding/validators/utility.validator.ts
@@ -1,0 +1,9 @@
+import { ValidationErrors, AbstractControl } from '@angular/forms';
+export abstract class UtilityValidator {
+  static BiggerThanZero(ctrl: AbstractControl): ValidationErrors | null {
+    if (!ctrl.value || !+ctrl.value) return { BiggerThanZero: true };
+    const val = +ctrl.value;
+    if (val > 0) return null;
+    return { BiggerThanZero: true };
+  }
+}

--- a/src/app/modules/onboarding/validators/utility.validator.ts
+++ b/src/app/modules/onboarding/validators/utility.validator.ts
@@ -1,4 +1,4 @@
-import { ValidationErrors, AbstractControl } from '@angular/forms';
+import { ValidationErrors, AbstractControl, FormGroup } from '@angular/forms';
 export abstract class UtilityValidator {
   static BiggerThanZero(ctrl: AbstractControl): ValidationErrors | null {
     if (!ctrl.value || !+ctrl.value) return { BiggerThanZero: true };
@@ -13,6 +13,13 @@ export abstract class UtilityValidator {
       return {
         incorectValue: true,
       };
+    };
+  }
+
+  static MustHaveMoreThanOneControle(grp: FormGroup): ValidationErrors | null {
+    if (Object.keys(grp.controls).length > 1) return null;
+    return {
+      mustSelectOne: true,
     };
   }
 }

--- a/src/app/modules/onboarding/validators/utility.validator.ts
+++ b/src/app/modules/onboarding/validators/utility.validator.ts
@@ -6,4 +6,13 @@ export abstract class UtilityValidator {
     if (val > 0) return null;
     return { BiggerThanZero: true };
   }
+
+  static MustBe(value: any): ValidationErrors | null {
+    return (ctrl: AbstractControl) => {
+      if (ctrl.value == value) return null;
+      return {
+        incorectValue: true,
+      };
+    };
+  }
 }

--- a/src/app/modules/onboarding/validators/utility.validator.ts
+++ b/src/app/modules/onboarding/validators/utility.validator.ts
@@ -1,15 +1,21 @@
 import { ValidationErrors, AbstractControl, FormGroup } from '@angular/forms';
 export abstract class UtilityValidator {
   static BiggerThanZero(ctrl: AbstractControl): ValidationErrors | null {
-    if (!ctrl.value || !+ctrl.value) return { BiggerThanZero: true };
+    if (!ctrl.value || !+ctrl.value) {
+      return { BiggerThanZero: true };
+    }
     const val = +ctrl.value;
-    if (val > 0) return null;
+    if (val > 0) {
+      return null;
+    }
     return { BiggerThanZero: true };
   }
 
   static MustBe(value: any): ValidationErrors | null {
     return (ctrl: AbstractControl) => {
-      if (ctrl.value == value) return null;
+      if (ctrl.value === value) {
+        return null;
+      }
       return {
         incorectValue: true,
       };
@@ -17,7 +23,9 @@ export abstract class UtilityValidator {
   }
 
   static MustHaveMoreThanOneControle(grp: FormGroup): ValidationErrors | null {
-    if (Object.keys(grp.controls).length > 1) return null;
+    if (Object.keys(grp.controls).length > 1) {
+      return null;
+    }
     return {
       mustSelectOne: true,
     };

--- a/src/app/modules/security/pages/change-password/change-password.component.spec.ts
+++ b/src/app/modules/security/pages/change-password/change-password.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MockService } from 'ng-mocks';
 import { of } from 'rxjs';
 import { AuthenticationService } from 'src/app/modules/core/services/authentication.service';
@@ -23,6 +24,7 @@ describe('ChangePasswordComponent', () => {
       ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         ReactiveFormsModule,
         FormsModule,
         MatFormFieldModule,

--- a/src/app/modules/security/security.module.ts
+++ b/src/app/modules/security/security.module.ts
@@ -3,12 +3,14 @@ import { CommonModule } from '@angular/common';
 import { ChangePasswordComponent } from './pages/change-password/change-password.component';
 import { SharedModule } from '../shared/shared.module';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [ChangePasswordComponent],
   imports: [
     CommonModule,
     SharedModule,
+    BrowserAnimationsModule,
     ReactiveFormsModule,
     FormsModule,
   ]

--- a/src/app/modules/shared/components/base.component.ts
+++ b/src/app/modules/shared/components/base.component.ts
@@ -1,0 +1,11 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class BaseComponent implements OnDestroy {
+  destroyed$ = new Subject<void>();
+  ngOnDestroy(): void {
+    this.destroyed$.next();
+    this.destroyed$.complete();
+  }
+}

--- a/src/app/modules/shared/components/base.component.ts
+++ b/src/app/modules/shared/components/base.component.ts
@@ -4,6 +4,9 @@ import { Subject } from 'rxjs';
 @Injectable({ providedIn: 'root' })
 export class BaseComponent implements OnDestroy {
   destroyed$ = new Subject<void>();
+  back() {
+    history.back();
+  }
   ngOnDestroy(): void {
     this.destroyed$.next();
     this.destroyed$.complete();

--- a/src/app/modules/shared/components/base.component.ts
+++ b/src/app/modules/shared/components/base.component.ts
@@ -4,7 +4,7 @@ import { Subject } from 'rxjs';
 @Injectable({ providedIn: 'root' })
 export class BaseComponent implements OnDestroy {
   destroyed$ = new Subject<void>();
-  back() {
+  back(): void {
     history.back();
   }
   ngOnDestroy(): void {

--- a/src/app/modules/shared/components/create-accounts-form/create-accounts-form.component.html
+++ b/src/app/modules/shared/components/create-accounts-form/create-accounts-form.component.html
@@ -8,7 +8,7 @@
     <mat-label>Number of accounts (max {{maxAccounts}})</mat-label>
     <input
       matInput
-      formControlName="numAccounts"
+      formControlName="numAccounts" 
       placeholder="Number of accounts to generate"
       name="numAccounts"
       type="number"

--- a/src/app/modules/shared/components/create-accounts-form/create-accounts-form.component.spec.ts
+++ b/src/app/modules/shared/components/create-accounts-form/create-accounts-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from '../../shared.module';
 
 import { CreateAccountsFormComponent } from './create-accounts-form.component';
@@ -14,6 +15,7 @@ describe('CreateAccountsFormComponent', () => {
       declarations: [ CreateAccountsFormComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         ReactiveFormsModule,
         FormsModule
       ]

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -27,7 +27,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatMenuModule } from '@angular/material/menu';
 import { ClipboardModule } from '@angular/cdk/clipboard';
-
+import { MatListModule } from '@angular/material/list';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 
 import { MomentModule } from 'ngx-moment';
@@ -46,6 +46,7 @@ import { AppRoutingModule } from 'src/app/app-routing.module';
 import { EpochPipe } from './pipes/format-epoch.pipe';
 import { SlotPipe } from './pipes/format-slot.pipe';
 import { BalancePipe } from './pipes/balance.pipe';
+import { CreateAccountsFormComponent } from './components/create-accounts-form/create-accounts-form.component';
 
 @NgModule({
   declarations: [
@@ -59,10 +60,9 @@ import { BalancePipe } from './pipes/balance.pipe';
     PasswordFormComponent,
     LoadingComponent,
     ImportAccountsFormComponent,
+    CreateAccountsFormComponent,
   ],
-  providers: [
-    BreadcrumbService,
-  ],
+  providers: [BreadcrumbService],
   imports: [
     CommonModule,
     MatIconModule,
@@ -73,12 +73,9 @@ import { BalancePipe } from './pipes/balance.pipe';
     MatInputModule,
     NgxFileDropModule,
     MatProgressBarModule,
-    AppRoutingModule,
   ],
   exports: [
     BreadcrumbComponent,
-    BrowserAnimationsModule,
-    BrowserAnimationsModule,
     MatSliderModule,
     MatGridListModule,
     MatCardModule,
@@ -116,6 +113,8 @@ import { BalancePipe } from './pipes/balance.pipe';
     EpochPipe,
     SlotPipe,
     BalancePipe,
+    CreateAccountsFormComponent,
+    MatListModule,
   ],
 })
-export class SharedModule { }
+export class SharedModule {}

--- a/src/app/modules/system-process/components/logs-stream/logs-stream.component.spec.ts
+++ b/src/app/modules/system-process/components/logs-stream/logs-stream.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { LogsStreamComponent } from './logs-stream.component';
@@ -12,6 +13,7 @@ describe('LogsStreamComponent', () => {
       declarations: [ LogsStreamComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ]
     })
     .compileComponents();

--- a/src/app/modules/system-process/pages/logs/logs.component.spec.ts
+++ b/src/app/modules/system-process/pages/logs/logs.component.spec.ts
@@ -6,6 +6,7 @@ import { LogsService } from '../../../core/services/logs.service';
 import { MockComponent, MockService } from 'ng-mocks';
 import { of } from 'rxjs';
 import { LogsStreamComponent } from '../../components/logs-stream/logs-stream.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('LogsComponent', () => {
   let component: LogsComponent;
@@ -16,6 +17,7 @@ describe('LogsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ],
       declarations: [
         LogsComponent,

--- a/src/app/modules/system-process/pages/metrics/metrics.component.spec.ts
+++ b/src/app/modules/system-process/pages/metrics/metrics.component.spec.ts
@@ -8,6 +8,7 @@ import { ProposedMissedChartComponent } from '../../components/proposed-missed-c
 import { DoubleBarChartComponent } from '../../components/double-bar-chart/double-bar-chart.component';
 import { PieChartComponent } from '../../components/pie-chart/pie-chart.component';
 import { MetricsComponent } from './metrics.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('MetricsComponent', () => {
   let component: MetricsComponent;
@@ -17,6 +18,7 @@ describe('MetricsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
         NgxEchartsModule.forRoot({
           echarts: () => import('echarts'),
         })

--- a/src/app/modules/system-process/system-process.module.ts
+++ b/src/app/modules/system-process/system-process.module.ts
@@ -12,6 +12,7 @@ import { DoubleBarChartComponent } from './components/double-bar-chart/double-ba
 import { PieChartComponent } from './components/pie-chart/pie-chart.component';
 import { LogsStreamComponent } from './components/logs-stream/logs-stream.component';
 import { PeerLocationsMapComponent } from './pages/peer-locations-map/peer-locations-map.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [
@@ -27,6 +28,7 @@ import { PeerLocationsMapComponent } from './pages/peer-locations-map/peer-locat
   imports: [
     CommonModule,
     SharedModule,
+    BrowserAnimationsModule,
     NgxEchartsModule.forRoot({
       echarts: () => import('echarts'),
     })

--- a/src/app/modules/wallet/components/account-actions/account-actions.component.html
+++ b/src/app/modules/wallet/components/account-actions/account-actions.component.html
@@ -1,4 +1,5 @@
-<div class="mt-6 mb-3 md:mb-0 md:mt-0 flex items-center" *ngIf="(walletConfig$ | async) as wallet">
+<div class="mt-6 mb-3 md:mb-0 md:mt-0 flex items-center" *ngIf="(walletConfig$ |
+  async) as wallet">
   <a routerLink="/dashboard/wallet/import">
     <button
       mat-raised-button
@@ -9,6 +10,15 @@
         <span class="mr-2">Import Keystores</span>
         <mat-icon>cloud_upload</mat-icon>
       </span>
+    </button>
+  </a>
+  <a class="ml-1"
+    [routerLink]="[ '/dashboard', 'wallet','voluntary-exit']">
+    <button mat-raised-button
+      color="accent"
+      class="large-btn ml-1">
+      Exit Validators
+      <mat-icon>exit_to_app</mat-icon>
     </button>
   </a>
 </div>

--- a/src/app/modules/wallet/components/account-actions/account-actions.component.html
+++ b/src/app/modules/wallet/components/account-actions/account-actions.component.html
@@ -1,6 +1,6 @@
 <div class="mt-6 mb-3 md:mb-0 md:mt-0 flex items-center" *ngIf="(walletConfig$ |
   async) as wallet">
-  <a routerLink="/dashboard/wallet/import">
+  <a routerLink="/dashboard/wallet/accounts/import">
     <button
       mat-raised-button
       color="accent"
@@ -13,7 +13,7 @@
     </button>
   </a>
   <a class="ml-1"
-    [routerLink]="[ '/dashboard', 'wallet','voluntary-exit']">
+    [routerLink]="[ '/dashboard', 'wallet','accounts','voluntary-exit']">
     <button mat-raised-button
       color="accent"
       class="large-btn ml-1">

--- a/src/app/modules/wallet/components/account-actions/account-actions.component.spec.ts
+++ b/src/app/modules/wallet/components/account-actions/account-actions.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MockService } from 'ng-mocks';
 import { of } from 'rxjs';
 import { WalletService } from 'src/app/modules/core/services/wallet.service';
@@ -20,6 +21,7 @@ describe('AccountActionsComponent', () => {
       declarations: [AccountActionsComponent],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ],
       providers: [
         { provide: WalletService, useValue: service }

--- a/src/app/modules/wallet/components/account-selections/account-selections.component.spec.ts
+++ b/src/app/modules/wallet/components/account-selections/account-selections.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { AccountSelectionsComponent } from './account-selections.component';
@@ -12,6 +13,7 @@ describe('AccountSelectionsComponent', () => {
       declarations: [AccountSelectionsComponent],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ]
     })
     .compileComponents();

--- a/src/app/modules/wallet/components/accounts-table/accounts-table.component.html
+++ b/src/app/modules/wallet/components/accounts-table/accounts-table.component.html
@@ -3,14 +3,14 @@
     <ng-container matColumnDef="select">
       <th mat-header-cell *matHeaderCellDef>
         <mat-checkbox (change)="$event ? masterToggle() : null"
-                      [checked]="selection?.hasValue() && isAllSelected()"
-                      [indeterminate]="selection?.hasValue() && !isAllSelected()">
+          [checked]="selection?.hasValue() && isAllSelected()"
+          [indeterminate]="selection?.hasValue() && !isAllSelected()">
         </mat-checkbox>
       </th>
       <td mat-cell *matCellDef="let row">
         <mat-checkbox (click)="$event.stopPropagation()"
-                      (change)="$event ? selection?.toggle(row) : null"
-                      [checked]="selection?.isSelected(row)">
+          (change)="$event ? selection?.toggle(row) : null"
+          [checked]="selection?.isSelected(row)">
         </mat-checkbox>
       </td>
     </ng-container>
@@ -22,13 +22,13 @@
 
     <ng-container matColumnDef="publicKey">
       <th mat-header-cell *matHeaderCellDef> Validating Public Key </th>
-      <td 
-        mat-cell 
-        *matCellDef="let row" 
+      <td
+        mat-cell
+        *matCellDef="let row"
         matTooltipPosition="left"
-        matTooltip="Copy to Clipboard" 
+        matTooltip="Copy to Clipboard"
         (click)="copyKeyToClipboard(row.publicKey)"
-        class="cursor-pointer"> 
+        class="cursor-pointer">
         {{row.publicKey | base64tohex | slice:0:8 }}...
       </td>
     </ng-container>
@@ -41,16 +41,19 @@
     <ng-container matColumnDef="balance">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>ETH Balance</th>
       <td mat-cell *matCellDef="let row">
-        <span [class.text-error]="row.lowBalance" [class.text-success]="!row.lowBalance">
+        <span [class.text-error]="row.lowBalance"
+          [class.text-success]="!row.lowBalance">
           {{row.balance | balance}}
         </span>
       </td>
     </ng-container>
 
     <ng-container matColumnDef="effectiveBalance">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header> ETH Effective Balance</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> ETH Effective
+        Balance</th>
       <td mat-cell *matCellDef="let row">
-        <span [class.text-error]="row.lowBalance" [class.text-success]="!row.lowBalance">
+        <span [class.text-error]="row.lowBalance"
+          [class.text-success]="!row.lowBalance">
           {{row.effectiveBalance | balance}}
         </span>
       </td>
@@ -80,10 +83,18 @@
         Actions
       </th>
       <td mat-cell *matCellDef="let row">
-        <app-icon-trigger-select
-          [menuItems]="menuItems"
-          [data]="row.publicKey"
-          icon="more_horiz"></app-icon-trigger-select>
+        <div class="flex">
+          <app-icon-trigger-select
+            [menuItems]="menuItems"
+            [data]="row.publicKey"
+            icon="more_horiz"></app-icon-trigger-select>
+          <a mat-icon-button
+            matTooltip="Exit validator"
+            [routerLink]="[ '/dashboard', 'wallet','voluntary-exit']"
+            [queryParams]="{publicKey:row.publicKey | base64tohex}">
+            <mat-icon>exit_to_app</mat-icon>
+          </a>
+        </div>
       </td>
     </ng-container>
 

--- a/src/app/modules/wallet/components/accounts-table/accounts-table.component.html
+++ b/src/app/modules/wallet/components/accounts-table/accounts-table.component.html
@@ -90,7 +90,7 @@
             icon="more_horiz"></app-icon-trigger-select>
           <a mat-icon-button
             matTooltip="Exit validator"
-            [routerLink]="[ '/dashboard', 'wallet','voluntary-exit']"
+            [routerLink]="[ '/dashboard', 'wallet','accounts','voluntary-exit']"
             [queryParams]="{publicKey:row.publicKey | base64tohex}">
             <mat-icon>exit_to_app</mat-icon>
           </a>

--- a/src/app/modules/wallet/components/accounts-table/accounts-table.component.spec.ts
+++ b/src/app/modules/wallet/components/accounts-table/accounts-table.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { AccountsTableComponent } from './accounts-table.component';
@@ -12,6 +13,7 @@ describe('AccountsTableComponent', () => {
       declarations: [AccountsTableComponent],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ]
     })
     .compileComponents();

--- a/src/app/modules/wallet/components/files-and-directories/files-and-directories.component.spec.ts
+++ b/src/app/modules/wallet/components/files-and-directories/files-and-directories.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { FilesAndDirectoriesComponent } from './files-and-directories.component';
@@ -12,6 +13,7 @@ describe('FilesAndDirectoriesComponent', () => {
       declarations: [ FilesAndDirectoriesComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ]
     })
     .compileComponents();

--- a/src/app/modules/wallet/components/icon-trigger-select/icon-trigger-select.component.spec.ts
+++ b/src/app/modules/wallet/components/icon-trigger-select/icon-trigger-select.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { IconTriggerSelectComponent } from './icon-trigger-select.component';
@@ -12,6 +13,7 @@ describe('IconTriggerSelectComponent', () => {
       declarations: [IconTriggerSelectComponent],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ]
     })
     .compileComponents();

--- a/src/app/modules/wallet/components/wallet-help/wallet-help.component.spec.ts
+++ b/src/app/modules/wallet/components/wallet-help/wallet-help.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { WalletHelpComponent } from './wallet-help.component';
@@ -12,6 +13,7 @@ describe('WalletHelpComponent', () => {
       declarations: [ WalletHelpComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ]
     })
     .compileComponents();

--- a/src/app/modules/wallet/components/wallet-kind/wallet-kind.component.spec.ts
+++ b/src/app/modules/wallet/components/wallet-kind/wallet-kind.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 
 import { WalletKindComponent } from './wallet-kind.component';
@@ -12,6 +13,7 @@ describe('WalletKindComponent', () => {
       declarations: [ WalletKindComponent ],
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ]
     })
     .compileComponents();

--- a/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.html
+++ b/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.html
@@ -9,13 +9,22 @@
                     Once these accounts are exited, the action cannot be
                     reverted.
                 </h3>
-                <mat-form-field class="w-100" *ngFor="let item of keys">
-                    <input matInput [formControlName]="item.accountName" />
-                </mat-form-field>
+                <mat-selection-list (selectionChange)="selectionChange($event)"
+                    #shoes>
+                    <mat-list-option
+                        [value]="item.validatingPublicKey|base64tohex"
+                        *ngFor="let item of keys">
+                        {{item.accountName}}
+                    </mat-list-option>
+                </mat-selection-list>
                 <mat-form-field class="w-100">
                     <mat-label>Confirmation</mat-label>
                     <input matInput formControlName="confirmation" />
-                    <mat-hint>Type agree if you want to exit the keys</mat-hint>
+                    <mat-hint>
+                        <h5>
+                            Type <i>'agree'</i> if you want to exit the keys
+                        </h5>
+                    </mat-hint>
                     <mat-error>
                         <span
                             *ngIf="exitAccountFormGroup?.get('confirmation')?.hasError('required')">

--- a/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.html
+++ b/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.html
@@ -1,0 +1,45 @@
+<app-breadcrumb></app-breadcrumb>
+<div class="md:w-2/3">
+    <form [formGroup]="exitAccountFormGroup" (ngSubmit)="confirmation()">
+        <mat-card class="bg-paper">
+            <mat-card-content>
+                <h3 class="text-accent">
+                    Are you sure you want exit these account?
+
+                    Once these accounts are exited, the action cannot be
+                    reverted.
+                </h3>
+                <mat-form-field class="w-100" *ngFor="let item of keys">
+                    <input matInput [formControlName]="item.accountName" />
+                </mat-form-field>
+                <mat-form-field class="w-100">
+                    <mat-label>Confirmation</mat-label>
+                    <input matInput formControlName="confirmation" />
+                    <mat-hint>Type agree if you want to exit the keys</mat-hint>
+                    <mat-error>
+                        <span
+                            *ngIf="exitAccountFormGroup?.get('confirmation')?.hasError('required')">
+                            The confirmation is required</span>
+
+                        <span
+                            *ngIf="exitAccountFormGroup?.get('confirmation')?.hasError('incorectValue')">
+                            You must type agree
+                        </span>
+                    </mat-error>
+                </mat-form-field>
+            </mat-card-content>
+            <mat-card-actions>
+                <div class="btn-container">
+                    <button mat-raised-button (click)="back()" color="accent">Back
+                        to
+                        Accounts</button>
+                    <button mat-raised-button mat-raised-button
+                        [disabled]="exitAccountFormGroup?.invalid"
+                        color="primary">
+                        Confirm
+                    </button>
+                </div>
+            </mat-card-actions>
+        </mat-card>
+    </form>
+</div>

--- a/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.spec.ts
+++ b/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.spec.ts
@@ -54,7 +54,7 @@ describe('AccountVoluntaryExitComponent', () => {
     };
 
     walletService.accounts = () => {
-      let accounts = {
+      const accounts = {
         accounts: [
           {
             validatingPublicKey: '12131231',
@@ -78,8 +78,9 @@ describe('AccountVoluntaryExitComponent', () => {
           } as Account,
         ],
       } as ListAccountsResponse;
-      return of(accounts);;
+      return of(accounts);
     };
+
     TestBed.configureTestingModule({
       declarations: [AccountVoluntaryExitComponent],
       imports: [

--- a/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.spec.ts
+++ b/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.spec.ts
@@ -1,0 +1,114 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountVoluntaryExitComponent } from './account-voluntary-exit.component';
+import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
+import { WalletService } from '../../../core/services/wallet.service';
+import { MockService } from 'ng-mocks';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SharedModule } from 'src/app/modules/shared/shared.module';
+import { of } from 'rxjs';
+import {
+  Account,
+  ListAccountsResponse,
+} from '../../../../proto/validator/accounts/v2/web_api';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('AccountVoluntaryExitComponent', () => {
+  let component: AccountVoluntaryExitComponent;
+  let fixture: ComponentFixture<AccountVoluntaryExitComponent>;
+  let activatedRouteStub: ActivatedRoute;
+  let walletService: WalletService;
+
+  beforeEach(async(() => {
+    walletService = MockService(WalletService);
+    activatedRouteStub = MockService(ActivatedRoute);
+    activatedRouteStub.snapshot = {
+      url: [],
+      params: {},
+      queryParams: {
+        publicKey: '',
+      },
+      fragment: '',
+      data: {},
+      outlet: '',
+      component: '',
+      routeConfig: {},
+      root: new ActivatedRouteSnapshot(),
+      parent: null,
+      children: [],
+      firstChild: null,
+      pathFromRoot: [],
+      paramMap: {
+        get: () => '',
+        getAll: () => [],
+        has: (str: string) => false,
+        keys: [],
+      },
+      queryParamMap: {
+        get: () => '',
+        getAll: () => [],
+        has: (str: string) => false,
+        keys: [],
+      },
+    };
+
+    walletService.accounts = () => {
+      let accounts = {
+        accounts: [
+          {
+            validatingPublicKey: '12131231',
+            accountName: 'merely-brief-gator',
+          } as Account,
+          {
+            validatingPublicKey: '12131231',
+            accountName: 'personally-conscious-echidna',
+          } as Account,
+          {
+            validatingPublicKey: '12131231',
+            accountName: 'slightly-amused-goldfish',
+          } as Account,
+          {
+            validatingPublicKey: '12131231',
+            accountName: 'nominally-present-bull',
+          } as Account,
+          {
+            validatingPublicKey: '12131231',
+            accountName: 'marginally-green-mare',
+          } as Account,
+        ],
+      } as ListAccountsResponse;
+      return of(accounts);;
+    };
+    TestBed.configureTestingModule({
+      declarations: [AccountVoluntaryExitComponent],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        SharedModule,
+        BrowserAnimationsModule,
+        HttpClientTestingModule,
+      ],
+      providers: [
+        {
+          provide: WalletService,
+          useValue: walletService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRouteStub,
+        },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AccountVoluntaryExitComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.ts
+++ b/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { BaseComponent } from '../../../shared/components/base.component';
-import { Observable } from 'rxjs';
 import { WalletService } from '../../../core/services/wallet.service';
-import { map, filter } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import {
   Account,
   AccountVoluntaryExitRequest,
@@ -61,10 +60,10 @@ export class AccountVoluntaryExitComponent
       });
   }
 
-  selectionChange(ev: MatSelectionListChange) {
-    if (this.exitAccountFormGroup?.get(ev.options[0].value))
+  selectionChange(ev: MatSelectionListChange): void {
+    if (this.exitAccountFormGroup?.get(ev.options[0].value)) {
       this.exitAccountFormGroup.removeControl(ev.options[0].value);
-    else {
+    } else {
       this.exitAccountFormGroup?.addControl(
         ev.options[0].value,
         this.formBuilder.control(ev.options[0].value)
@@ -72,25 +71,34 @@ export class AccountVoluntaryExitComponent
     }
   }
 
-  confirmation() {
-    if (this.exitAccountFormGroup?.invalid) return false;
-    const request = <AccountVoluntaryExitRequest>{
+  confirmation(): void | boolean {
+    if (this.exitAccountFormGroup?.invalid) {
+      return false;
+    }
+    const request = {
       publicKeys: this.keys.map((x) => x.validatingPublicKey),
       confrimation: this.exitAccountFormGroup?.get('confirmatio')?.value,
-    };
+    } as AccountVoluntaryExitRequest;
+
     this.walletService.exitAccounts(request).subscribe((x) => {
-      const removedKeys = Object.keys(this.exitAccountFormGroup?.controls??{}).length-1
-      this.snackMsgService.open(`Successfully exited from ${removedKeys} keys`,'Success',{
-        direction:'rtl',
-        politeness:'assertive',
-        duration:4000
-      })
+      const removedKeys =
+        Object.keys(this.exitAccountFormGroup?.controls ?? {}).length - 1;
+      this.snackMsgService.open(
+        `Successfully exited from ${removedKeys} keys`,
+        'Success',
+        {
+          direction: 'rtl',
+          politeness: 'assertive',
+          duration: 4000,
+        }
+      );
       this.back();
     });
   }
+
   private searchbyPublicKey(publicKey: any, x: Account[]): Account[] {
     return publicKey
-      ? x.filter((c) => base64ToHex(c.validatingPublicKey) == publicKey)
+      ? x.filter((c) => base64ToHex(c.validatingPublicKey) === publicKey)
       : x;
   }
 }

--- a/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.ts
+++ b/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.ts
@@ -7,10 +7,17 @@ import {
   Account,
   AccountVoluntaryExitRequest,
 } from '../../../../proto/validator/accounts/v2/web_api';
-import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import {
+  FormGroup,
+  FormBuilder,
+  Validators,
+  AbstractControlOptions,
+} from '@angular/forms';
 import { UtilityValidator } from '../../../onboarding/validators/utility.validator';
 import { ActivatedRoute } from '@angular/router';
 import { base64ToHex } from 'src/app/modules/core/utils/hex-util';
+import { MatSelectionListChange } from '@angular/material/list';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-account-voluntary-exit',
@@ -23,6 +30,7 @@ export class AccountVoluntaryExitComponent
   constructor(
     private walletService: WalletService,
     private activatedRoute: ActivatedRoute,
+    private snackMsgService: MatSnackBar,
     private formBuilder: FormBuilder
   ) {
     super();
@@ -31,28 +39,37 @@ export class AccountVoluntaryExitComponent
   keys: Account[] = [];
   ngOnInit(): void {
     const publicKey = this.activatedRoute.snapshot.queryParams.publicKey;
-    this.exitAccountFormGroup = this.formBuilder.group({
-      confirmation: [
-        '',
-        [Validators.required, UtilityValidator.MustBe('agree')],
-      ],
-    });
+    this.exitAccountFormGroup = this.formBuilder.group(
+      {
+        confirmation: [
+          '',
+          [Validators.required, UtilityValidator.MustBe('agree')],
+        ],
+      },
+      {
+        validators: UtilityValidator.MustHaveMoreThanOneControle,
+      } as AbstractControlOptions
+    );
 
     this.walletService
       .accounts()
       .pipe(map((x) => this.searchbyPublicKey(publicKey, x.accounts)))
       .subscribe((accs) => {
         accs.forEach((acc) => {
-          this.keys.push(acc),
-            this.exitAccountFormGroup?.addControl(
-              acc.accountName,
-              this.formBuilder.control({
-                value: acc.accountName,
-                disabled: true,
-              })
-            );
+          this.keys.push(acc);
         });
       });
+  }
+
+  selectionChange(ev: MatSelectionListChange) {
+    if (this.exitAccountFormGroup?.get(ev.options[0].value))
+      this.exitAccountFormGroup.removeControl(ev.options[0].value);
+    else {
+      this.exitAccountFormGroup?.addControl(
+        ev.options[0].value,
+        this.formBuilder.control(ev.options[0].value)
+      );
+    }
   }
 
   confirmation() {
@@ -61,7 +78,15 @@ export class AccountVoluntaryExitComponent
       publicKeys: this.keys.map((x) => x.validatingPublicKey),
       confrimation: this.exitAccountFormGroup?.get('confirmatio')?.value,
     };
-    this.walletService.exitAccounts(request).subscribe((x) => this.back());
+    this.walletService.exitAccounts(request).subscribe((x) => {
+      const removedKeys = Object.keys(this.exitAccountFormGroup?.controls??{}).length-1
+      this.snackMsgService.open(`Successfully exited from ${removedKeys} keys`,'Success',{
+        direction:'rtl',
+        politeness:'assertive',
+        duration:4000
+      })
+      this.back();
+    });
   }
   private searchbyPublicKey(publicKey: any, x: Account[]): Account[] {
     return publicKey

--- a/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.ts
+++ b/src/app/modules/wallet/pages/account-voluntary-exit/account-voluntary-exit.component.ts
@@ -1,0 +1,71 @@
+import { Component, OnInit } from '@angular/core';
+import { BaseComponent } from '../../../shared/components/base.component';
+import { Observable } from 'rxjs';
+import { WalletService } from '../../../core/services/wallet.service';
+import { map, filter } from 'rxjs/operators';
+import {
+  Account,
+  AccountVoluntaryExitRequest,
+} from '../../../../proto/validator/accounts/v2/web_api';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { UtilityValidator } from '../../../onboarding/validators/utility.validator';
+import { ActivatedRoute } from '@angular/router';
+import { base64ToHex } from 'src/app/modules/core/utils/hex-util';
+
+@Component({
+  selector: 'app-account-voluntary-exit',
+  templateUrl: './account-voluntary-exit.component.html',
+  styleUrls: ['./account-voluntary-exit.component.scss'],
+})
+export class AccountVoluntaryExitComponent
+  extends BaseComponent
+  implements OnInit {
+  constructor(
+    private walletService: WalletService,
+    private activatedRoute: ActivatedRoute,
+    private formBuilder: FormBuilder
+  ) {
+    super();
+  }
+  exitAccountFormGroup: FormGroup | undefined | null;
+  keys: Account[] = [];
+  ngOnInit(): void {
+    const publicKey = this.activatedRoute.snapshot.queryParams.publicKey;
+    this.exitAccountFormGroup = this.formBuilder.group({
+      confirmation: [
+        '',
+        [Validators.required, UtilityValidator.MustBe('agree')],
+      ],
+    });
+
+    this.walletService
+      .accounts()
+      .pipe(map((x) => this.searchbyPublicKey(publicKey, x.accounts)))
+      .subscribe((accs) => {
+        accs.forEach((acc) => {
+          this.keys.push(acc),
+            this.exitAccountFormGroup?.addControl(
+              acc.accountName,
+              this.formBuilder.control({
+                value: acc.accountName,
+                disabled: true,
+              })
+            );
+        });
+      });
+  }
+
+  confirmation() {
+    if (this.exitAccountFormGroup?.invalid) return false;
+    const request = <AccountVoluntaryExitRequest>{
+      publicKeys: this.keys.map((x) => x.validatingPublicKey),
+      confrimation: this.exitAccountFormGroup?.get('confirmatio')?.value,
+    };
+    this.walletService.exitAccounts(request).subscribe((x) => this.back());
+  }
+  private searchbyPublicKey(publicKey: any, x: Account[]): Account[] {
+    return publicKey
+      ? x.filter((c) => base64ToHex(c.validatingPublicKey) == publicKey)
+      : x;
+  }
+}

--- a/src/app/modules/wallet/pages/accounts/accounts.component.spec.ts
+++ b/src/app/modules/wallet/pages/accounts/accounts.component.spec.ts
@@ -11,6 +11,7 @@ import { AccountSelectionsComponent } from '../../components/account-selections/
 import { AccountActionsComponent } from '../../components/account-actions/account-actions.component';
 import { AccountsTableComponent } from '../../components/accounts-table/accounts-table.component';
 import { AccountsComponent } from './accounts.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('AccountsComponent', () => {
   let component: AccountsComponent;
@@ -31,6 +32,7 @@ describe('AccountsComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         SharedModule,
+        BrowserAnimationsModule,
       ],
       declarations: [
         AccountsComponent,

--- a/src/app/modules/wallet/pages/import/import.component.spec.ts
+++ b/src/app/modules/wallet/pages/import/import.component.spec.ts
@@ -1,6 +1,7 @@
 import { APP_BASE_HREF } from '@angular/common';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MockService } from 'ng-mocks';
@@ -33,6 +34,7 @@ describe('ImportComponent', () => {
         RouterTestingModule,
         SharedModule,
         FormsModule,
+        BrowserAnimationsModule,
         ReactiveFormsModule,
         NgxFileDropModule,
       ],

--- a/src/app/modules/wallet/pages/wallet-details/wallet-details.component.spec.ts
+++ b/src/app/modules/wallet/pages/wallet-details/wallet-details.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MockComponent, MockService } from 'ng-mocks';
 import { of } from 'rxjs';
 
@@ -24,14 +25,9 @@ describe('WalletDetailsComponent', () => {
         MockComponent(WalletHelpComponent),
         MockComponent(FilesAndDirectoriesComponent),
       ],
-      imports: [
-        SharedModule,
-      ],
-      providers: [
-        { provide: WalletService, useValue: service },
-      ]
-    })
-    .compileComponents();
+      imports: [SharedModule, BrowserAnimationsModule],
+      providers: [{ provide: WalletService, useValue: service }],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/modules/wallet/wallet.component.ts
+++ b/src/app/modules/wallet/wallet.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+@Component({
+  selector: 'wallet-component',
+  styles: [''],
+  template: `
+    <router-outlet></router-outlet>
+  `,
+})
+export class WalletComponent implements OnInit {
+  constructor() {}
+  ngOnInit() {}
+}

--- a/src/app/modules/wallet/wallet.component.ts
+++ b/src/app/modules/wallet/wallet.component.ts
@@ -1,12 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 @Component({
-  selector: 'wallet-component',
+  selector: 'app-wallet-component',
   styles: [''],
-  template: `
-    <router-outlet></router-outlet>
-  `,
+  template: ` <router-outlet></router-outlet> `,
 })
 export class WalletComponent implements OnInit {
   constructor() {}
-  ngOnInit() {}
+  ngOnInit(): void {}
 }

--- a/src/app/modules/wallet/wallet.module.ts
+++ b/src/app/modules/wallet/wallet.module.ts
@@ -15,9 +15,13 @@ import { AccountSelectionsComponent } from './components/account-selections/acco
 import { AccountActionsComponent } from './components/account-actions/account-actions.component';
 import { ImportComponent } from './pages/import/import.component';
 import { NgxFileDropModule } from 'ngx-file-drop';
+import { AccountVoluntaryExitComponent } from './pages/account-voluntary-exit/account-voluntary-exit.component';
+import { WalletRoutingModule } from './wallet.routing.module';
+import { WalletComponent } from './wallet.component';
 
 @NgModule({
   declarations: [
+    WalletComponent,
     AccountsComponent,
     IconTriggerSelectComponent,
     WalletDetailsComponent,
@@ -28,14 +32,15 @@ import { NgxFileDropModule } from 'ngx-file-drop';
     AccountSelectionsComponent,
     AccountActionsComponent,
     ImportComponent,
+    AccountVoluntaryExitComponent,
   ],
   imports: [
+    WalletRoutingModule,
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    RouterModule,
     SharedModule,
-    NgxFileDropModule
+    NgxFileDropModule,
   ],
 })
-export class WalletModule { }
+export class WalletModule {}

--- a/src/app/modules/wallet/wallet.routing.module.ts
+++ b/src/app/modules/wallet/wallet.routing.module.ts
@@ -29,6 +29,20 @@ const routes: Routes = [
             path: '',
             component: AccountsComponent,
           },
+          {
+            path: 'voluntary-exit',
+            data: {
+              breadcrumb: 'Voluntary Exit',
+            },
+            component: AccountVoluntaryExitComponent,
+          },
+          {
+            path: 'import',
+            data: {
+              breadcrumb: 'Import Accounts',
+            },
+            component: ImportComponent,
+          },
         ],
       },
       {
@@ -37,20 +51,6 @@ const routes: Routes = [
           breadcrumb: 'Wallet Details',
         },
         component: WalletDetailsComponent,
-      },
-      {
-        path: 'import',
-        data: {
-          breadcrumb: 'Import Accounts',
-        },
-        component: ImportComponent,
-      },
-      {
-        path: 'voluntary-exit',
-        data: {
-          breadcrumb: 'Account Voluntary Exit',
-        },
-        component: AccountVoluntaryExitComponent,
       },
     ],
   },

--- a/src/app/modules/wallet/wallet.routing.module.ts
+++ b/src/app/modules/wallet/wallet.routing.module.ts
@@ -1,0 +1,62 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { AccountVoluntaryExitComponent } from './pages/account-voluntary-exit/account-voluntary-exit.component';
+import { AccountsComponent } from './pages/accounts/accounts.component';
+import { ImportComponent } from './pages/import/import.component';
+import { WalletDetailsComponent } from './pages/wallet-details/wallet-details.component';
+import { WalletComponent } from './wallet.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: WalletComponent,
+    data: {
+      breadcrumb: 'Wallet',
+    },
+    children: [
+      {
+        path: '',
+        redirectTo: 'accounts',
+        pathMatch: 'full',
+      },
+      {
+        path: 'accounts',
+        data: {
+          breadcrumb: 'Accounts',
+        },
+        children: [
+          {
+            path: '',
+            component: AccountsComponent,
+          },
+        ],
+      },
+      {
+        path: 'details',
+        data: {
+          breadcrumb: 'Wallet Details',
+        },
+        component: WalletDetailsComponent,
+      },
+      {
+        path: 'import',
+        data: {
+          breadcrumb: 'Import Accounts',
+        },
+        component: ImportComponent,
+      },
+      {
+        path: 'voluntary-exit',
+        data: {
+          breadcrumb: 'Account Voluntary Exit',
+        },
+        component: AccountVoluntaryExitComponent,
+      },
+    ],
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class WalletRoutingModule {}

--- a/src/app/proto/validator/accounts/v2/web_api.ts
+++ b/src/app/proto/validator/accounts/v2/web_api.ts
@@ -206,13 +206,13 @@ export interface RecoverWalletRequest {
   /**
    * 24 word Mnemonics
    */
-  Mnemonic: string;
+  mnemonic: string;
   /**
    * Num of accounts generated from the mnemonic
    */
-  Num_accounts: string;
+  num_accounts: string;
   /**
    * The wallet password
    */
-  Wallet_password: string;
+  wallet_password: string;
 }

--- a/src/app/proto/validator/accounts/v2/web_api.ts
+++ b/src/app/proto/validator/accounts/v2/web_api.ts
@@ -216,3 +216,14 @@ export interface RecoverWalletRequest {
    */
   wallet_password: string;
 }
+
+export interface AccountVoluntaryExitRequest {
+  /**
+   * The key from the accounts that will be removed
+   */
+  publicKeys: string[];
+  /**
+   * Confirmation if the exit should proceed or not
+   */
+  confrimation: string;
+}

--- a/src/app/proto/validator/accounts/v2/web_api.ts
+++ b/src/app/proto/validator/accounts/v2/web_api.ts
@@ -201,3 +201,18 @@ export interface ValidateKeystoresRequest {
    */
   keystoresPassword: string;
 }
+
+export interface RecoverWalletRequest {
+  /**
+   * 24 word Mnemonics
+   */
+  Mnemonic: string;
+  /**
+   * Num of accounts generated from the mnemonic
+   */
+  Num_accounts: string;
+  /**
+   * The wallet password
+   */
+  Wallet_password: string;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -74,7 +74,18 @@ $prysm-secondary: (
     A700: white,
   )
 );
-
+.text-accent {
+  color: $secondary !important;
+}
+.w-100{
+  width: 100% !important;
+}
+.flex{
+  display: flex !important;
+}
+.justify-content-between{
+  justify-content: space-between;
+}
 // Create the theme object. A theme consists of configurations for individual
 // theming systems such as "color" or "typography".
 $prysm-web-ui-theme: mat-dark-theme((


### PR DESCRIPTION
Created Account voluntary exit component

added some styles in the Styles.css

added AccountVoluntaryExitRequest in web.api.ts

added a new method in the wallet service for exiting the keys.

Modified the account list for navigation to the Account exit screen.

Had to update all of the specs because migrating the wallet module to be lazy-loaded required removing the browser animation module from the shared module. So I had to import it in the specs also