### PR TITLE
ansi_up 4.0.4 to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,9 +2817,9 @@
       }
     },
     "ansi_up": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-4.0.4.tgz",
-      "integrity": "sha512-vRxC8q6QY918MbehO869biJW4tiunJdjOhi5fpY6NLOliBQlZhOkKgABJKJqH+JZfb/WfjvjN1chLWI6tODerw=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-5.0.1.tgz",
+      "integrity": "sha512-HGOTjFQECRKZM9fIlGhJfR2pcK8PMUWzFOqcPwqBEnNIa4P2r0Di+g2hxCX0hL0n1NUtAHGRA+fUyA/OajZYFw=="
     },
     "anymatch": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@angular/router": "^10.0.14",
     "@types/echarts": "^4.9.3",
     "@types/file-saver": "^2.0.1",
-    "ansi_up": "^4.0.4",
+    "ansi_up": "^5.0.0",
     "echarts": "^4.9.0",
     "ethers": "^5.0.30",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
The npm package ansi_up converts ANSI escape codes into HTML. In ansi_up v4, ANSI escape codes can be used to create HTML hyperlinks. Due to insufficient URL sanitization, this feature is affected by a cross-site scripting (XSS) vulnerability. This issue is fixed in v5.0.0.