### PR TITLE
Update ethers.js to 5.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1619,393 +1619,392 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.12.tgz",
-      "integrity": "sha512-Ujr/3bwyYYjXLDQfebeiiTuvOw9XtUKM8av6YkoBeMXyGQM9GkjrQlwJMNwGTmqjATH/ZNbRgCh98GjOLiIB1Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.3.0.tgz",
+      "integrity": "sha512-NaT4UacjOwca8qCG/gv8k+DgTcWu49xlrvdhr/p8PTFnoS8e3aMWqjI3znFME5Txa/QWXDrg2/heufIUue9rtw==",
       "requires": {
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/hash": "^5.0.10",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/address": "^5.3.0",
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/constants": "^5.3.0",
+        "@ethersproject/hash": "^5.3.0",
+        "@ethersproject/keccak256": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/strings": "^5.3.0"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.9.tgz",
-      "integrity": "sha512-X9fMkqpeu9ayC3JyBkeeZhn35P4xQkpGX/l+FrxDtEW9tybf/UWXSMi8bGThpPtfJ6q6U2LDetXSpSwK4TfYQQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.3.0.tgz",
+      "integrity": "sha512-1+MLhGP1GwxBDBNwMWVmhCsvKwh4gK7oIfOrmlmePNeskg1NhIrYssraJBieaFNHUYfKEd/1DjiVZMw8Qu5Cxw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/networks": "^5.0.7",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/transactions": "^5.0.9",
-        "@ethersproject/web": "^5.0.12"
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/networks": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/transactions": "^5.3.0",
+        "@ethersproject/web": "^5.3.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.12.tgz",
-      "integrity": "sha512-qt4jAEzQGPZ31My1gFGPzzJHJveYhVycW7RHkuX0W8fvMdg7wr0uvP7mQEptMVrb+jYwsVktCf6gBGwWDpFiTA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.3.0.tgz",
+      "integrity": "sha512-w8IFwOYqiPrtvosPuArZ3+QPR2nmdVTRrVY8uJYL3NNfMmQfTy3V3l2wbzX47UUlNbPJY+gKvzJAyvK1onZxJg==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.8",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7"
+        "@ethersproject/abstract-provider": "^5.3.0",
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.10.tgz",
-      "integrity": "sha512-70vqESmW5Srua1kMDIN6uVfdneZMaMyRYH4qPvkAXGkbicrCOsA9m01vIloA4wYiiF+HLEfL1ENKdn5jb9xiAw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.3.0.tgz",
+      "integrity": "sha512-29TgjzEBK+gUEUAOfWCG7s9IxLNLCqvr+oDSk6L9TXD0VLvZJKhJV479tKQqheVA81OeGxfpdxYtUVH8hqlCvA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/rlp": "^5.0.7"
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/keccak256": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/rlp": "^5.3.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.8.tgz",
-      "integrity": "sha512-PNbpHOMgZpZ1skvQl119pV2YkCPXmZTxw+T92qX0z7zaMFPypXWTZBzim+hUceb//zx4DFjeGT4aSjZRTOYThg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.3.0.tgz",
+      "integrity": "sha512-JIqgtOmgKcbc2sjGWTXyXktqUhvFUDte8fPVsAaOrcPiJf6YotNF+nsrOYGC9pbHBEGSuSBp3QR0varkO8JHEw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9"
+        "@ethersproject/bytes": "^5.3.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.8.tgz",
-      "integrity": "sha512-PCVKZIShBQUqAXjJSvaCidThPvL0jaaQZcewJc0sf8Xx05BizaOS8r3jdPdpNdY+/qZtRDqwHTSKjvR/xssyLQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.3.0.tgz",
+      "integrity": "sha512-8J4nS6t/SOnoCgr3DF5WCSRLC5YwTKYpZWJqeyYQLX+86TwPhtzvHXacODzcDII9tWKhVg6g0Bka8JCBWXsCiQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/properties": "^5.0.7"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.14.tgz",
-      "integrity": "sha512-Q4TjMq9Gg3Xzj0aeJWqJgI3tdEiPiET7Y5OtNtjTAODZ2kp4y9jMNg97zVcvPedFvGROdpGDyCI77JDFodUzOw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.3.0.tgz",
+      "integrity": "sha512-5xguJ+Q1/zRMgHgDCaqAexx/8DwDVLRemw2i6uR8KyGjwGdXI8f32QZZ1cKGucBN6ekJvpUpHy6XAuQnTv0mPA==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "bn.js": "^4.4.0"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "bn.js": "^4.11.9"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.10.tgz",
-      "integrity": "sha512-vpu0v1LZ1j1s9kERQIMnVU69MyHEzUff7nqK9XuCU4vx+AM8n9lU2gj7jtJIvGSt9HzatK/6I6bWusI5nyuaTA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.3.0.tgz",
+      "integrity": "sha512-rqLJjdVqCcn7glPer7Fxh87PRqlnRScVAoxcIP3PmOUNApMWJ6yRdOFfo2KvPAdO7Le3yEI1o0YW+Yvr7XCYvw==",
       "requires": {
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.9.tgz",
-      "integrity": "sha512-2uAKH89UcaJP/Sc+54u92BtJtZ4cPgcS1p0YbB1L3tlkavwNvth+kNCUplIB1Becqs7BOZr0B/3dMNjhJDy4Dg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.3.0.tgz",
+      "integrity": "sha512-4y1feNOwEpgjAfiCFWOHznvv6qUF/H6uI0UKp8xdhftb+H+FbKflXg1pOgH5qs4Sr7EYBL+zPyPb+YD5g1aEyw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13"
+        "@ethersproject/bignumber": "^5.3.0"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.10.tgz",
-      "integrity": "sha512-h9kdvllwT6B1LyUXeNQIb7Y6u6ZprP5LUiQIjSqvOehhm1sFZcaVtydsSa0LIg3SBC5QF0M7zH5p7EtI2VD0rQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.3.0.tgz",
+      "integrity": "sha512-eDyQ8ltykvyQqnGZxb/c1e0OnEtzqXhNNC4BX8nhYBCaoBrYYuK/1fLmyEvc5+XUMoxNhwpYkoSSwvPLci7/Zg==",
       "requires": {
-        "@ethersproject/abi": "^5.0.10",
-        "@ethersproject/abstract-provider": "^5.0.8",
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7"
+        "@ethersproject/abi": "^5.3.0",
+        "@ethersproject/abstract-provider": "^5.3.0",
+        "@ethersproject/abstract-signer": "^5.3.0",
+        "@ethersproject/address": "^5.3.0",
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/constants": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/transactions": "^5.3.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.11.tgz",
-      "integrity": "sha512-H3KJ9fk33XWJ2djAW03IL7fg3DsDMYjO1XijiUb1hJ85vYfhvxu0OmsU7d3tg2Uv1H1kFSo8ghr3WFQ8c+NL3g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.3.0.tgz",
+      "integrity": "sha512-gAFZSjUPQ32CIfoKSMtMEQ+IO0kQxqhwz9fCIFt2DtAq2u4pWt8mL9Z5P0r6KkLcQU8LE9FmuPPyd+JvBzmr1w==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/abstract-signer": "^5.3.0",
+        "@ethersproject/address": "^5.3.0",
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/keccak256": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/strings": "^5.3.0"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.9.tgz",
-      "integrity": "sha512-S5UMmIC6XfFtqhUK4uTjD8GPNzSbE+sZ/0VMqFnA3zAJ+cEFZuEyhZDYnl2ItGJzjT4jsy+uEy1SIl3baYK1PQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.3.0.tgz",
+      "integrity": "sha512-zLmmtLNoDMGoYRdjOab01Zqkvp+TmZyCGDAMQF1Bs3yZyBs/kzTNi1qJjR1jVUcPP5CWGtjFwY8iNG8oNV9J8g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/basex": "^5.0.7",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/pbkdf2": "^5.0.7",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/sha2": "^5.0.7",
-        "@ethersproject/signing-key": "^5.0.8",
-        "@ethersproject/strings": "^5.0.8",
-        "@ethersproject/transactions": "^5.0.9",
-        "@ethersproject/wordlists": "^5.0.8"
+        "@ethersproject/abstract-signer": "^5.3.0",
+        "@ethersproject/basex": "^5.3.0",
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/pbkdf2": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/sha2": "^5.3.0",
+        "@ethersproject/signing-key": "^5.3.0",
+        "@ethersproject/strings": "^5.3.0",
+        "@ethersproject/transactions": "^5.3.0",
+        "@ethersproject/wordlists": "^5.3.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.11.tgz",
-      "integrity": "sha512-0GhWScWUlXXb4qJNp0wmkU95QS3YdN9UMOfMSEl76CRANWWrmyzxcBVSXSBu5iQ0/W8wO+xGlJJ3tpA6v3mbIw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.3.0.tgz",
+      "integrity": "sha512-/xwbqaIb5grUIGNmeEaz8GdcpmDr++X8WT4Jqcclnxow8PXCUHFeDxjf3O+nSuoqOYG/Ds0+BI5xuQKbva6Xkw==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/hdnode": "^5.0.8",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/pbkdf2": "^5.0.7",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/random": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8",
-        "@ethersproject/transactions": "^5.0.9",
+        "@ethersproject/abstract-signer": "^5.3.0",
+        "@ethersproject/address": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/hdnode": "^5.3.0",
+        "@ethersproject/keccak256": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/pbkdf2": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/random": "^5.3.0",
+        "@ethersproject/strings": "^5.3.0",
+        "@ethersproject/transactions": "^5.3.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.8.tgz",
-      "integrity": "sha512-zoGbwXcWWs9MX4NOAZ7N0hhgIRl4Q/IO/u9c/RHRY4WqDy3Ywm0OLamEV53QDwhjwn3YiiVwU1Ve5j7yJ0a/KQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.3.0.tgz",
+      "integrity": "sha512-Gv2YqgIUmRbYVNIibafT0qGaeGYLIA/EdWHJ7JcVxVSs2vyxafGxOJ5VpSBHWeOIsE6OOaCelYowhuuTicgdFQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
+        "@ethersproject/bytes": "^5.3.0",
         "js-sha3": "0.5.7"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.9.tgz",
-      "integrity": "sha512-kV3Uamv3XOH99Xf3kpIG3ZkS7mBNYcLDM00JSDtNgNB4BihuyxpQzIZPRIDmRi+95Z/R1Bb0X2kUNHa/kJoVrw=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.3.0.tgz",
+      "integrity": "sha512-8bwJ2gxJGkZZnpQSq5uSiZSJjyVTWmlGft4oH8vxHdvO1Asy4TwVepAhPgxIQIMxXZFUNMych1YjIV4oQ4I7dA=="
     },
     "@ethersproject/networks": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.8.tgz",
-      "integrity": "sha512-PYpptlO2Tu5f/JEBI5hdlMds5k1DY1QwVbh3LKPb3un9dQA2bC51vd2/gRWAgSBpF3kkmZOj4FhD7ATLX4H+DA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.3.0.tgz",
+      "integrity": "sha512-XGbD9MMgqrR7SYz8o6xVgdG+25v7YT5vQG8ZdlcLj2I7elOBM7VNeQrnxfSN7rWQNcqu2z80OM29gGbQz+4Low==",
       "requires": {
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.8.tgz",
-      "integrity": "sha512-UlmAMGbIPaS2xXsI38FbePVTfJMuU9jnwcqVn3p88HxPF4kD897ha+l3TNsBqJqf32UbQL5GImnf1oJkSKq4vQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.3.0.tgz",
+      "integrity": "sha512-Q9ChVU6gBFiex0FSdtzo4b0SAKz3ZYcYVFLrEWHL0FnHvNk3J3WgAtRNtBQGQYn/T5wkoTdZttMbfBkFlaiWcA==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/sha2": "^5.0.7"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/sha2": "^5.3.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.8.tgz",
-      "integrity": "sha512-zEnLMze2Eu2VDPj/05QwCwMKHh506gpT9PP9KPVd4dDB+5d6AcROUYVLoIIQgBYK7X/Gw0UJmG3oVtnxOQafAw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.3.0.tgz",
+      "integrity": "sha512-PaHxJyM5/bfusk6vr3yP//JMnm4UEojpzuWGTmtL5X4uNhNnFNvlYilZLyDr4I9cTkIbipCMsAuIcXWsmdRnEw==",
       "requires": {
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.0.22",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.22.tgz",
-      "integrity": "sha512-6C6agQsz/7FRFfZFok+m1HVUS6G+IU1grLwBx9+W11SF3UeP8vquXRMVDfOiKWyvy+g4bJT1+9C/QuC8lG08DQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.3.0.tgz",
+      "integrity": "sha512-HtL+DEbzPcRyfrkrMay7Rk/4he+NbUpzI/wHXP4Cqtra82nQOnqqCgTQc4HbdDrl75WVxG/JRMFhyneIPIMZaA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.8",
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/basex": "^5.0.7",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/hash": "^5.0.10",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/networks": "^5.0.7",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/random": "^5.0.7",
-        "@ethersproject/rlp": "^5.0.7",
-        "@ethersproject/sha2": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8",
-        "@ethersproject/transactions": "^5.0.9",
-        "@ethersproject/web": "^5.0.12",
+        "@ethersproject/abstract-provider": "^5.3.0",
+        "@ethersproject/abstract-signer": "^5.3.0",
+        "@ethersproject/address": "^5.3.0",
+        "@ethersproject/basex": "^5.3.0",
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/constants": "^5.3.0",
+        "@ethersproject/hash": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/networks": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/random": "^5.3.0",
+        "@ethersproject/rlp": "^5.3.0",
+        "@ethersproject/sha2": "^5.3.0",
+        "@ethersproject/strings": "^5.3.0",
+        "@ethersproject/transactions": "^5.3.0",
+        "@ethersproject/web": "^5.3.0",
         "bech32": "1.1.4",
-        "ws": "7.2.3"
+        "ws": "7.4.6"
       },
       "dependencies": {
         "ws": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
         }
       }
     },
     "@ethersproject/random": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.8.tgz",
-      "integrity": "sha512-4rHtotmd9NjklW0eDvByicEkL+qareIyFSbG1ShC8tPJJSAC0g55oQWzw+3nfdRCgBHRuEE7S8EcPcTVPvZ9cA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.3.0.tgz",
+      "integrity": "sha512-A5SL/4inutSwt3Fh2OD0x2gz+x6GHmuUnIPkR7zAiTidMD2N8F6tZdMF1hlQKWVCcVMWhEQg8mWijhEzm6BBYw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.8.tgz",
-      "integrity": "sha512-E4wdFs8xRNJfzNHmnkC8w5fPeT4Wd1U2cust3YeT16/46iSkLT8nn8ilidC6KhR7hfuSZE4UqSPzyk76p7cdZg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.3.0.tgz",
+      "integrity": "sha512-oI0joYpsRanl9guDubaW+1NbcpK0vJ3F/6Wpcanzcnqq+oaW9O5E98liwkEDPcb16BUTLIJ+ZF8GPIHYxJ/5Pw==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.8.tgz",
-      "integrity": "sha512-ILP1ZgyvDj4rrdE+AXrTv9V88m7x87uga2VZ/FeULKPumOEw/4bGnJz/oQ8zDnDvVYRCJ+48VaQBS2CFLbk1ww==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.3.0.tgz",
+      "integrity": "sha512-r5ftlwKcocYEuFz2JbeKOT5SAsCV4m1RJDsTOEfQ5L67ZC7NFDK5i7maPdn1bx4nPhylF9VAwxSrQ1esmwzylg==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "hash.js": "1.1.3"
-      },
-      "dependencies": {
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        }
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.10.tgz",
-      "integrity": "sha512-w5it3GbFOvN6e0mTd5gDNj+bwSe6L9jqqYjU+uaYS8/hAEp4qYLk5p8ZjbJJkNn7u1p0iwocp8X9oH/OdK8apA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.3.0.tgz",
+      "integrity": "sha512-+DX/GwHAd0ok1bgedV1cKO0zfK7P/9aEyNoaYiRsGHpCecN7mhLqcdoUiUzE7Uz86LBsxm5ssK0qA1kBB47fbQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "elliptic": "6.5.4"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.9.tgz",
-      "integrity": "sha512-LIxSAYEQgLRXE3mRPCq39ou61kqP8fDrGqEeNcaNJS3aLbmAOS8MZp56uK++WsdI9hj8sNsFh78hrAa6zR9Jag==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.3.0.tgz",
+      "integrity": "sha512-uLRBaNUiISHbut94XKewJgQh6UmydWTBp71I7I21pkjVXfZO2dJ5EOo3jCnumJc01M4LOm79dlNNmF3oGIvweQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/sha2": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/keccak256": "^5.3.0",
+        "@ethersproject/sha2": "^5.3.0",
+        "@ethersproject/strings": "^5.3.0"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.9.tgz",
-      "integrity": "sha512-ogxBpcUpdO524CYs841MoJHgHxEPUy0bJFDS4Ezg8My+WYVMfVAOlZSLss0Rurbeeam8CpUVDzM4zUn09SU66Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.3.0.tgz",
+      "integrity": "sha512-j/AzIGZ503cvhuF2ldRSjB0BrKzpsBMtCieDtn4TYMMZMQ9zScJn9wLzTQl/bRNvJbBE6TOspK0r8/Ngae/f2Q==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/constants": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.10.tgz",
-      "integrity": "sha512-Tqpp+vKYQyQdJQQk4M73tDzO7ODf2D42/sJOcKlDAAbdSni13v6a+31hUdo02qYXhVYwIs+ZjHnO4zKv5BNk8w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.3.0.tgz",
+      "integrity": "sha512-cdfK8VVyW2oEBCXhURG0WQ6AICL/r6Gmjh0e4Bvbv6MCn/GBd8FeBH3rtl7ho+AW50csMKeGv3m3K1HSHB2jMQ==",
       "requires": {
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/rlp": "^5.0.7",
-        "@ethersproject/signing-key": "^5.0.8"
+        "@ethersproject/address": "^5.3.0",
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/constants": "^5.3.0",
+        "@ethersproject/keccak256": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/rlp": "^5.3.0",
+        "@ethersproject/signing-key": "^5.3.0"
       }
     },
     "@ethersproject/units": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.10.tgz",
-      "integrity": "sha512-eaiHi9ham5lbC7qpqxpae7OY/nHJUnRUnFFuEwi2VB5Nwe3Np468OAV+e+HR+jAK4fHXQE6PFBTxWGtnZuO37g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.3.0.tgz",
+      "integrity": "sha512-BkfccZGwfJ6Ob+AelpIrgAzuNhrN2VLp3AILnkqTOv+yBdsc83V4AYf25XC/u0rHnWl6f4POaietPwlMqP2vUg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/constants": "^5.0.8",
-        "@ethersproject/logger": "^5.0.8"
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/constants": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.11.tgz",
-      "integrity": "sha512-2Fg/DOvUltR7aZTOyWWlQhru+SKvq2UE3uEhXSyCFgMqDQNuc2nHXh1SHJtN65jsEbjVIppOe1Q7EQMvhmeeRw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.3.0.tgz",
+      "integrity": "sha512-boYBLydG6671p9QoG6EinNnNzbm7DNOjVT20eV8J6HQEq4aUaGiA2CytF2vK+2rOEWbzhZqoNDt6AlkE1LlsTg==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.8",
-        "@ethersproject/abstract-signer": "^5.0.10",
-        "@ethersproject/address": "^5.0.9",
-        "@ethersproject/bignumber": "^5.0.13",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/hash": "^5.0.10",
-        "@ethersproject/hdnode": "^5.0.8",
-        "@ethersproject/json-wallets": "^5.0.10",
-        "@ethersproject/keccak256": "^5.0.7",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/random": "^5.0.7",
-        "@ethersproject/signing-key": "^5.0.8",
-        "@ethersproject/transactions": "^5.0.9",
-        "@ethersproject/wordlists": "^5.0.8"
+        "@ethersproject/abstract-provider": "^5.3.0",
+        "@ethersproject/abstract-signer": "^5.3.0",
+        "@ethersproject/address": "^5.3.0",
+        "@ethersproject/bignumber": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/hash": "^5.3.0",
+        "@ethersproject/hdnode": "^5.3.0",
+        "@ethersproject/json-wallets": "^5.3.0",
+        "@ethersproject/keccak256": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/random": "^5.3.0",
+        "@ethersproject/signing-key": "^5.3.0",
+        "@ethersproject/transactions": "^5.3.0",
+        "@ethersproject/wordlists": "^5.3.0"
       }
     },
     "@ethersproject/web": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.13.tgz",
-      "integrity": "sha512-G3x/Ns7pQm21ALnWLbdBI5XkW/jrsbXXffI9hKNPHqf59mTxHYtlNiSwxdoTSwCef3Hn7uvGZpaSgTyxs7IufQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.3.0.tgz",
+      "integrity": "sha512-Ni6/DHnY6k/TD41LEkv0RQDx4jqWz5e/RZvrSecsxGYycF+MFy2z++T/yGc2peRunLOTIFwEksgEGGlbwfYmhQ==",
       "requires": {
-        "@ethersproject/base64": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/base64": "^5.3.0",
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/strings": "^5.3.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.9.tgz",
-      "integrity": "sha512-Sn6MTjZkfbriod6GG6+p43W09HOXT4gwcDVNj0YoPYlo4Zq2Fk6b1CU9KUX3c6aI17PrgYb4qwZm5BMuORyqyQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.3.0.tgz",
+      "integrity": "sha512-JcwumCZcsUxgWpiFU/BRy6b4KlTRdOmYvOKZcAw/3sdF93/pZyPW5Od2hFkHS8oWp4xS06YQ+qHqQhdcxdHafQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.9",
-        "@ethersproject/hash": "^5.0.10",
-        "@ethersproject/logger": "^5.0.8",
-        "@ethersproject/properties": "^5.0.7",
-        "@ethersproject/strings": "^5.0.8"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/hash": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/properties": "^5.3.0",
+        "@ethersproject/strings": "^5.3.0"
       }
     },
     "@fullhuman/postcss-purgecss": {
@@ -5765,40 +5764,40 @@
       "dev": true
     },
     "ethers": {
-      "version": "5.0.30",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.30.tgz",
-      "integrity": "sha512-CdY/zb8d0uEBaWNmDkAVWXO8FLs2plAPOjgukgYC95L5VKIZzZaCav7PAeG2IqGico4vtNu8l3ibXdXd6FqjrQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.3.0.tgz",
+      "integrity": "sha512-myN+338S4sFQZvQ9trii7xit8Hu/LnUtjA0ROFOHpUreQc3fgLZEMNVqF3vM1u2D78DIIeG1TbuozVCVlXQWvQ==",
       "requires": {
-        "@ethersproject/abi": "5.0.12",
-        "@ethersproject/abstract-provider": "5.0.9",
-        "@ethersproject/abstract-signer": "5.0.12",
-        "@ethersproject/address": "5.0.10",
-        "@ethersproject/base64": "5.0.8",
-        "@ethersproject/basex": "5.0.8",
-        "@ethersproject/bignumber": "5.0.14",
-        "@ethersproject/bytes": "5.0.10",
-        "@ethersproject/constants": "5.0.9",
-        "@ethersproject/contracts": "5.0.10",
-        "@ethersproject/hash": "5.0.11",
-        "@ethersproject/hdnode": "5.0.9",
-        "@ethersproject/json-wallets": "5.0.11",
-        "@ethersproject/keccak256": "5.0.8",
-        "@ethersproject/logger": "5.0.9",
-        "@ethersproject/networks": "5.0.8",
-        "@ethersproject/pbkdf2": "5.0.8",
-        "@ethersproject/properties": "5.0.8",
-        "@ethersproject/providers": "5.0.22",
-        "@ethersproject/random": "5.0.8",
-        "@ethersproject/rlp": "5.0.8",
-        "@ethersproject/sha2": "5.0.8",
-        "@ethersproject/signing-key": "5.0.10",
-        "@ethersproject/solidity": "5.0.9",
-        "@ethersproject/strings": "5.0.9",
-        "@ethersproject/transactions": "5.0.10",
-        "@ethersproject/units": "5.0.10",
-        "@ethersproject/wallet": "5.0.11",
-        "@ethersproject/web": "5.0.13",
-        "@ethersproject/wordlists": "5.0.9"
+        "@ethersproject/abi": "5.3.0",
+        "@ethersproject/abstract-provider": "5.3.0",
+        "@ethersproject/abstract-signer": "5.3.0",
+        "@ethersproject/address": "5.3.0",
+        "@ethersproject/base64": "5.3.0",
+        "@ethersproject/basex": "5.3.0",
+        "@ethersproject/bignumber": "5.3.0",
+        "@ethersproject/bytes": "5.3.0",
+        "@ethersproject/constants": "5.3.0",
+        "@ethersproject/contracts": "5.3.0",
+        "@ethersproject/hash": "5.3.0",
+        "@ethersproject/hdnode": "5.3.0",
+        "@ethersproject/json-wallets": "5.3.0",
+        "@ethersproject/keccak256": "5.3.0",
+        "@ethersproject/logger": "5.3.0",
+        "@ethersproject/networks": "5.3.0",
+        "@ethersproject/pbkdf2": "5.3.0",
+        "@ethersproject/properties": "5.3.0",
+        "@ethersproject/providers": "5.3.0",
+        "@ethersproject/random": "5.3.0",
+        "@ethersproject/rlp": "5.3.0",
+        "@ethersproject/sha2": "5.3.0",
+        "@ethersproject/signing-key": "5.3.0",
+        "@ethersproject/solidity": "5.3.0",
+        "@ethersproject/strings": "5.3.0",
+        "@ethersproject/transactions": "5.3.0",
+        "@ethersproject/units": "5.3.0",
+        "@ethersproject/wallet": "5.3.0",
+        "@ethersproject/web": "5.3.0",
+        "@ethersproject/wordlists": "5.3.0"
       }
     },
     "eventemitter3": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/file-saver": "^2.0.1",
     "ansi_up": "^5.0.0",
     "echarts": "^4.9.0",
-    "ethers": "^5.0.30",
+    "ethers": "^5.3.0",
     "file-saver": "^2.0.5",
     "jszip": "^3.6.0",
     "leaflet": "^1.7.1",


### PR DESCRIPTION
Ethers.js prior to 5.3.0 was using a vulnerable version of ws (7.2.3) which is vulnerable to Regular Expression Denial of Service (ReDoS). A specially crafted value of the Sec-Websocket-Protocol header can be used to significantly slow down a ws server. The vulnerability has been fixed in ws@7.4.6 which has been implemented in ethers.js 5.3.0.

https://github.com/ethers-io/ethers.js/releases/tag/v5.3.0
https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff