### PR TITLE
Removing secondsLeftInQueue that is always overwritten

### DIFF
--- a/src/app/modules/dashboard/components/activation-queue/activation-queue.component.ts
+++ b/src/app/modules/dashboard/components/activation-queue/activation-queue.component.ts
@@ -103,9 +103,7 @@ export class ActivationQueueComponent {
       });
     }
     let secondsLeftInQueue: number;
-    if (queue.churnLimit >= activationKeysSet.size) {
-      secondsLeftInQueue = 1;
-    }
+
     const epochsLeft = activationKeysSet.size / queue.churnLimit;
     secondsLeftInQueue = epochsLeft * SECONDS_PER_EPOCH;
 


### PR DESCRIPTION
The secondsLeftInQueue variable inside the if statement is always overwritten after the if statement.