### PR TITLE
Improving validator key validation 

### DIFF
--- a/src/app/modules/onboarding/pages/hd-wallet-wizard/hd-wallet-wizard.component.html
+++ b/src/app/modules/onboarding/pages/hd-wallet-wizard/hd-wallet-wizard.component.html
@@ -53,7 +53,7 @@
                       color="primary"
                       mat-raised-button
                       (click)="createWallet($event)"
-                      [disabled]="walletPasswordFormGroup.invalid">
+                      [disabled]="!walletPasswordFormGroup.valid">
                       Create Wallet
                     </button>
                   </span>

--- a/src/app/modules/onboarding/pages/nonhd-wallet-wizard/nonhd-wallet-wizard.component.html
+++ b/src/app/modules/onboarding/pages/nonhd-wallet-wizard/nonhd-wallet-wizard.component.html
@@ -18,7 +18,7 @@
               <app-import-protection #slashingProtection></app-import-protection>
               <div class="mt-6">
                 <button color="accent" mat-raised-button (click)="resetOnboarding()">Back to Wallets</button>
-                <span class="ml-4"><button color="primary" mat-raised-button (click)="nextStep($event, states.UnlockAccounts)" [disabled]="keystoresFormGroup.invalid || slashingProtection.invalid">Continue</button></span>
+                <span class="ml-4"><button color="primary" mat-raised-button (click)="nextStep($event, states.UnlockAccounts)" [disabled]="!keystoresFormGroup.valid || slashingProtection.invalid">Continue</button></span>
               </div>
             </mat-step>
             <mat-step [stepControl]="walletPasswordFormGroup" label="Wallet">

--- a/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
+++ b/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
@@ -66,24 +66,24 @@ export class ImportAccountsFormComponent implements OnInit {
       this.changeDetectorRef.detectChanges();
     });
 
-    this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.valueChanges.pipe(
-      debounceTime(700),
-    ).subscribe(password =>{
-      if (this.keystorePasswordDefaultFormGroup.status === "VALID"){
-        console.log(password )
+    this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.statusChanges.subscribe(status =>{
+      console.log(this.keystoresImported)
+      if (status === "VALID"){
+        console.log(this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.value)
         this.keystoresImported.controls.forEach(fg => {
-          fg.get('keystorePassword')?.setValue(password);
+          fg.get('keystorePassword')?.setValue(this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.value);
           fg.get('keystorePassword')?.updateValueAndValidity();
           fg.get('keystorePassword')?.markAsPristine();
         });
       } else {
-        console.log(password )
+        console.log(this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.value)
         this.keystoresImported.controls.forEach(fg => {
           fg.get('keystorePassword')?.setValue("");
           fg.get('keystorePassword')?.updateValueAndValidity();
           fg.get('keystorePassword')?.markAsPristine();
         });
       }
+      console.log(this.keystorePasswordDefaultFormGroup)
     });
   }
 

--- a/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
+++ b/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
@@ -46,7 +46,6 @@ export class ImportAccountsFormComponent implements OnInit {
           fg.updateValueAndValidity()
          
         });
-        console.log("async is back")
         this.keystorePasswordDefaultFormGroup.clearAsyncValidators();
         this.keystorePasswordDefaultFormGroup.updateValueAndValidity();
       } else {
@@ -67,23 +66,19 @@ export class ImportAccountsFormComponent implements OnInit {
     });
 
     this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.statusChanges.subscribe(status =>{
-      console.log(this.keystoresImported)
       if (status === "VALID"){
-        console.log(this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.value)
         this.keystoresImported.controls.forEach(fg => {
           fg.get('keystorePassword')?.setValue(this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.value);
           fg.get('keystorePassword')?.updateValueAndValidity();
           fg.get('keystorePassword')?.markAsPristine();
         });
       } else {
-        console.log(this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.value)
         this.keystoresImported.controls.forEach(fg => {
           fg.get('keystorePassword')?.setValue("");
           fg.get('keystorePassword')?.updateValueAndValidity();
           fg.get('keystorePassword')?.markAsPristine();
         });
       }
-      console.log(this.keystorePasswordDefaultFormGroup)
     });
   }
 
@@ -189,7 +184,6 @@ export class ImportAccountsFormComponent implements OnInit {
     let keystores: string[] = this.keystoresImported.controls.map((fg) => {
       return JSON.stringify(fg.get('keystore')?.value)
     });
-   console.log(this.uniqueToggleFormControl.value)
     if (this.uniqueToggleFormControl.value === false) {
       this.keystorePasswordDefaultFormGroup.clearAsyncValidators();
       this.keystorePasswordDefaultFormGroup.addAsyncValidators([this.keystoreValidator.correctPassword(keystores)]);

--- a/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
+++ b/src/app/modules/shared/components/import-accounts-form/import-accounts-form.component.ts
@@ -38,22 +38,52 @@ export class ImportAccountsFormComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.uniqueToggleFormControl.valueChanges.subscribe((value) => {
+    this.uniqueToggleFormControl.valueChanges.subscribe((value:boolean) => {
       this.keystorePasswordDefaultFormGroup.reset(this.keystorePasswordDefaultFormGroupInit);
+      if (value == true) {
+        this.keystoresImported.controls.forEach(fg => {
+          fg.addAsyncValidators([this.keystoreValidator.correctPassword()])
+          fg.updateValueAndValidity()
+         
+        });
+        console.log("async is back")
+        this.keystorePasswordDefaultFormGroup.clearAsyncValidators();
+        this.keystorePasswordDefaultFormGroup.updateValueAndValidity();
+      } else {
+        let keystores: string[] = this.keystoresImported.controls.map((fg) => {
+          fg.clearAsyncValidators()
+          fg.updateValueAndValidity();
+          return JSON.stringify(fg.get('keystore')?.value)
+        });
+        this.keystorePasswordDefaultFormGroup.addAsyncValidators([this.keystoreValidator.correctPassword(keystores)]);
+        this.keystorePasswordDefaultFormGroup.updateValueAndValidity();
+      }
       this.keystoresImported.controls.forEach(fg => {
         fg.get('keystorePassword')?.markAsPristine();
       });
+     
       // Angular doesn't detect changes fast enough after so we need to check for changes again...
       this.changeDetectorRef.detectChanges();
     });
+
     this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.valueChanges.pipe(
-      debounceTime(250),
+      debounceTime(700),
     ).subscribe(password =>{
-      this.keystoresImported.controls.forEach(fg => {
-        fg.get('keystorePassword')?.setValue(password);
-        fg.get('keystorePassword')?.updateValueAndValidity();
-        fg.get('keystorePassword')?.markAsPristine();
-      });
+      if (this.keystorePasswordDefaultFormGroup.status === "VALID"){
+        console.log(password )
+        this.keystoresImported.controls.forEach(fg => {
+          fg.get('keystorePassword')?.setValue(password);
+          fg.get('keystorePassword')?.updateValueAndValidity();
+          fg.get('keystorePassword')?.markAsPristine();
+        });
+      } else {
+        console.log(password )
+        this.keystoresImported.controls.forEach(fg => {
+          fg.get('keystorePassword')?.setValue("");
+          fg.get('keystorePassword')?.updateValueAndValidity();
+          fg.get('keystorePassword')?.markAsPristine();
+        });
+      }
     });
   }
 
@@ -149,21 +179,23 @@ export class ImportAccountsFormComponent implements OnInit {
       fileName: [fileName],
       keystore: [jsonFile],
       keystorePassword: ['', [Validators.required,  Validators.minLength(8)]],
-    },{
-      asyncValidators: [this.keystoreValidator.correctPassword()]
     });
+    if (this.uniqueToggleFormControl.value === true) {
+      keystoresFormGroup.addAsyncValidators([this.keystoreValidator.correctPassword()]);
+      this.keystorePasswordDefaultFormGroup.updateValueAndValidity();
+    }
     
     this.keystoresImported?.push(keystoresFormGroup);
-    
-    // updates the keystorePasswordDefaultFormGroup based on each keystore
-    this.keystoresImported.controls.forEach((fg) => {
-      fg.get('keystorePassword')?.statusChanges.subscribe(status =>{
-        if(status === 'INVALID'){
-          this.keystorePasswordDefaultFormGroup.get('keystorePassword')?.setErrors( fg.get('keystorePassword')?.errors || {});
-        }
-      });
-    })
-    
+    let keystores: string[] = this.keystoresImported.controls.map((fg) => {
+      return JSON.stringify(fg.get('keystore')?.value)
+    });
+   console.log(this.uniqueToggleFormControl.value)
+    if (this.uniqueToggleFormControl.value === false) {
+      this.keystorePasswordDefaultFormGroup.clearAsyncValidators();
+      this.keystorePasswordDefaultFormGroup.addAsyncValidators([this.keystoreValidator.correctPassword(keystores)]);
+      this.keystorePasswordDefaultFormGroup.updateValueAndValidity();
+    } 
+   
   }
 
   private isKeystoreFileValid(jsonFile: object): boolean {

--- a/src/app/modules/shared/validators/keystore.validator.ts
+++ b/src/app/modules/shared/validators/keystore.validator.ts
@@ -42,8 +42,6 @@ export class KeystoreValidator {
             keystores: keystores ?? [JSON.stringify(keystoreFG.keystore)],
             keystores_password: keystoresPassword,
           };
-          console.log("async validator"+req.keystores)
-
           return this.walletService.validateKeystores(req).pipe(
             switchMap(() => {
               control.get('keystorePassword')?.setErrors(null);

--- a/src/app/modules/shared/validators/keystore.validator.ts
+++ b/src/app/modules/shared/validators/keystore.validator.ts
@@ -24,7 +24,7 @@ export class KeystoreValidator {
     return null;
   }
 
-  correctPassword(): AsyncValidatorFn {
+  correctPassword(keystores?:string[]): AsyncValidatorFn {
     return (
       control: AbstractControl
     ): Observable<{ [key: string]: any } | null> => {
@@ -39,9 +39,11 @@ export class KeystoreValidator {
             return of(null);
           }
           const req: ValidateKeystoresRequest = {
-            keystores: [JSON.stringify(keystoreFG.keystore)],
+            keystores: keystores ?? [JSON.stringify(keystoreFG.keystore)],
             keystores_password: keystoresPassword,
           };
+          console.log("async validator"+req.keystores)
+
           return this.walletService.validateKeystores(req).pipe(
             switchMap(() => {
               control.get('keystorePassword')?.setErrors(null);


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

- Validator keys that use the same password was spinning up too many validation requests which were leading to OOM on the instance which lead to crashes. We attempt to solve this by grouping the validator request into a single request for processing.
- the continue button was also changing to enabled status while the validator form was still in pending status.

**Which issues(s) does this PR fix?**

Fixes #11544

**Other notes for review**
