### PR TITLE
Rename module from github.com/prysmaticlabs/prysm-web-ui to github.com/OffchainLabs/prysm-web-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,6 @@
 **WEB UI IS STILL DEPRECATED AND WILL BE FROZEN UNTIL NEXT STEPS ARE DETERMINED**
 
 - updates to fix vulnerabilities
-- removal of hex to base64 as APIs update from https://github.com/prysmaticlabs/prysm-web-ui/pull/249, depends on https://github.com/prysmaticlabs/prysm/pull/13191
+- removal of hex to base64 as APIs update from https://github.com/OffchainLabs/prysm-web-ui/pull/249, depends on https://github.com/prysmaticlabs/prysm/pull/13191
 
-**Full Changelog**: https://github.com/prysmaticlabs/prysm-web-ui/compare/v2.0.4...v2.0.5
+**Full Changelog**: https://github.com/OffchainLabs/prysm-web-ui/compare/v2.0.4...v2.0.5


### PR DESCRIPTION
Part of https://github.com/prysmaticlabs/prysm/issues/15139
